### PR TITLE
Fixed: compile error on systems where _fseeki64 isn't defined

### DIFF
--- a/fex/Data_Reader.cpp
+++ b/fex/Data_Reader.cpp
@@ -627,7 +627,7 @@ fseeko(FILE *stream, off_t pos, int whence)
 blargg_err_t Std_File_Reader::seek_v( BOOST::uint64_t n )
 {
 #ifdef _WIN32
-	if ( _fseeki64( STATIC_CAST(FILE*, file_), n, SEEK_SET ) )
+	if ( fseek( STATIC_CAST(FILE*, file_), n, SEEK_SET ) )
 #else
     if ( fseeko( STATIC_CAST(FILE*, file_), n, SEEK_SET ) )
 #endif


### PR DESCRIPTION
As .nes files don't really get greater than 2 GiB, we might be able to solve this compile error by swapping out _fseeki64() for fseek().

Another possibility is to isolate each compiler that doesn't support _fseeki64. For example, 
ac4b7eda63ccd01e80b9618cbe91859921b0f732. However, this doesn't seem like a scalable solution.
