### PR TITLE
cleanups: Fix compilation without NDEBUG (dprintf)

### DIFF
--- a/nes_emu/Nes_Fme7_Apu.cpp
+++ b/nes_emu/Nes_Fme7_Apu.cpp
@@ -50,13 +50,6 @@ void Nes_Fme7_Apu::run_until( blip_time_t end_time )
 		if ( !oscs [index].output )
 			continue;
 		
-		// check for unsupported mode
-		#ifndef NDEBUG
-			if ( (mode & 011) <= 001 && vol_mode & 0x1f )
-				dprintf( "FME7 used unimplemented sound mode: %02X, vol_mode: %02X\n",
-						mode, vol_mode & 0x1f );
-		#endif
-		
 		if ( (mode & 001) | (vol_mode & 0x10) )
 			volume = 0; // noise and envelope aren't supported
 		

--- a/nes_emu/Nes_Mapper.cpp
+++ b/nes_emu/Nes_Mapper.cpp
@@ -155,8 +155,6 @@ void Nes_Mapper::mirror_manual( int page0, int page1, int page2, int page3 )
 #ifndef NDEBUG
 int Nes_Mapper::handle_bus_conflict( nes_addr_t addr, int data )
 {
-	if ( emu().Nes_Cpu::get_code( addr ) [0] != data )
-		dprintf( "Mapper write had bus conflict\n" );
 	return data;
 }
 #endif


### PR DESCRIPTION
Commit a63b5a2202a32e13f451d7ded0b0191fe1f00894 removed the dprintf define and its usage in most of the places. Two places were left that prevent the core from being compiled with not defined NDEBUG.