### PR TITLE
Revert 'Better error handling'

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -267,9 +267,6 @@ bool retro_load_game(const struct retro_game_info *info)
       { 0 },
    };
 
-   if (!info)
-      return false;
-
    environ_cb(RETRO_ENVIRONMENT_SET_INPUT_DESCRIPTORS, desc);
 
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_RGB565;


### PR DESCRIPTION
This reverts commit https://github.com/libretro/QuickNES_Core/commit/f7238df6bbde4659cd5f06ac840bc50116e66dec

This is not needed to prevent a segfault so might as well be removed. See libretro/RetroArch#4493