### PR TITLE
Fix save game loading for battery enabled roms

### DIFF
--- a/nes_emu/Nes_Core.cpp
+++ b/nes_emu/Nes_Core.cpp
@@ -330,7 +330,7 @@ void Nes_Core::reset( bool full_reset, bool erase_battery_ram )
 		
 		// SRAM
 		lrom_readable = 0;
-		sram_present = false;
+		sram_present = true;
 		enable_sram( false );
 		if ( !cart->has_battery_ram() || erase_battery_ram )
 			memset( impl->sram, 0xFF, impl->sram_size );


### PR DESCRIPTION
Battery-enabled games are not able to load the save game file even if it exists, so, quicknes always rewrites a new one. This PR should fix this.

reference issue:
https://github.com/libretro/QuickNES_Core/issues/8