### PR TITLE
Use RETRO_MEMORY_SAVE_RAM only when battery is enabled

### DIFF
--- a/nes_emu/Nes_Core.cpp
+++ b/nes_emu/Nes_Core.cpp
@@ -63,6 +63,7 @@ void Nes_Core::close()
 	disable_rendering();
 }
 
+extern bool has_battery_ram;
 const char * Nes_Core::open( Nes_Cart const* new_cart )
 {
 	close();
@@ -72,12 +73,14 @@ const char * Nes_Core::open( Nes_Cart const* new_cart )
 	mapper = Nes_Mapper::create( new_cart, this );
 	if ( !mapper ) 
 		return unsupported_mapper;
-	
+
 	RETURN_ERR( ppu.open_chr( new_cart->chr(), new_cart->chr_size() ) );
 	
 	cart = new_cart;
+	has_battery_ram = cart->has_battery_ram();
 	memset( impl->unmapped_page, unmapped_fill, sizeof impl->unmapped_page );
 	reset( true, true );
+
 	return 0;
 }
 


### PR DESCRIPTION
This avoids constant writes to save file (and log spamming during save ram changed if anyone is using write interval) when rom loaded does not have battery bit enabled but game is using the wram.

Added RETRO_ENVIRONMENT_SET_MEMORY_MAPS to handle cheevos requirements for system ram and wram access for both battery and non-battery enabled retroarchievement-compatible titles.

@meleu @leiradel @twinaphex 