### PR TITLE
Android: Fix issue cause my unaligned mem access

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -31,7 +31,7 @@ else
 endif
 
 LOCAL_SRC_FILES    =  $(SOURCES_CXX)
-LOCAL_CXXFLAGS = -DANDROID -D__LIBRETRO__ -Wall -Wno-multichar -Wno-unused-variable -Wno-sign-compare $(APP_OPTIM) $(INCFLAGS) -DGIT_VERSION=\"$(GIT_VERSION)\"
+LOCAL_CXXFLAGS = -DANDROID -D__LIBRETRO__ -Wall -Wno-multichar -Wno-unused-variable -Wno-sign-compare $(APP_OPTIM) $(INCFLAGS) -DGIT_VERSION=\"$(GIT_VERSION)\" -DNO_UNALIGNED_ACCESS
 
 LOCAL_C_INCLUDES = $(INCFLAGS)
 


### PR DESCRIPTION
With @bparker06 hint regarding unaligned access in android, and @aliaspider previous PR to solve related issue in other systems, applying -DNO_UNALIGNED_ACCESS to android during compile also fixes crashing in some android devices.

Fixes at least the following issues:
https://github.com/libretro/QuickNES_Core/issues/37
https://github.com/libretro/QuickNES_Core/issues/6