### PR TITLE
Audio Buffer Saving and VRC7 Audio Savestate Fix

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -41,6 +41,7 @@ SOURCES_CXX := \
 	$(CORE_DIR)/nes_emu/Mapper_Vrc7.cpp \
 	$(CORE_DIR)/nes_emu/Nes_Vrc7.cpp \
 	$(CORE_DIR)/nes_emu/emu2413.cpp \
+	$(CORE_DIR)/nes_emu/emu2413_state.cpp \
 	$(CORE_DIR)/nes_emu/Nes_Namco_Apu.cpp \
 	$(CORE_DIR)/nes_emu/Mmc24.cpp \
 	$(CORE_DIR)/nes_emu/Nes_Oscs.cpp \

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -169,6 +169,15 @@ static void update_audio_mode(void)
 			}
 		}
 	}
+	else
+	{
+		//if the environment callback failed (won't happen), just set the nonlinear buffer
+		if (current_buffer != &nes_buffer)
+		{
+			emu->set_sample_rate(44100, &nes_buffer);
+			current_buffer = &nes_buffer;
+		}
+	}
 
 	var.key = "quicknes_audio_eq";
 	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -206,6 +215,12 @@ static void update_audio_mode(void)
 			emu->set_equalizer(Nes_Emu::nes_eq);
 		}
 	}
+	else
+	{
+		//if the environment callback failed (won't happen), just set the default NES equalizer
+		emu->set_equalizer(Nes_Emu::nes_eq);
+	}
+
 
 }
 

--- a/libretro/libretro.h
+++ b/libretro/libretro.h
@@ -1088,8 +1088,12 @@ struct retro_vfs_interface_info
 
 enum retro_hw_render_interface_type
 {
-   RETRO_HW_RENDER_INTERFACE_VULKAN = 0,
-   RETRO_HW_RENDER_INTERFACE_DUMMY = INT_MAX
+	RETRO_HW_RENDER_INTERFACE_VULKAN = 0,
+	RETRO_HW_RENDER_INTERFACE_D3D9   = 1,
+	RETRO_HW_RENDER_INTERFACE_D3D10  = 2,
+	RETRO_HW_RENDER_INTERFACE_D3D11  = 3,
+	RETRO_HW_RENDER_INTERFACE_D3D12  = 4,
+   RETRO_HW_RENDER_INTERFACE_DUMMY  = INT_MAX
 };
 
 /* Base struct. All retro_hw_render_interface_* types
@@ -1103,7 +1107,7 @@ struct retro_hw_render_interface
 
 #define RETRO_ENVIRONMENT_GET_LED_INTERFACE (46 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                            /* struct retro_led_interface * --
-                                            * Gets an interface which is used by a libretro core to set 
+                                            * Gets an interface which is used by a libretro core to set
                                             * state of LEDs.
                                             */
 
@@ -1113,6 +1117,47 @@ struct retro_led_interface
     retro_set_led_state_t set_led_state;
 };
 
+#define RETRO_ENVIRONMENT_GET_AUDIO_VIDEO_ENABLE (47 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* int * --
+                                            * Tells the core if the frontend wants audio or video.
+                                            * If disabled, the frontend will discard the audio or video,
+                                            * so the core may decide to skip generating a frame or generating audio.
+                                            * This is mainly used for increasing performance.
+                                            * Bit 0 (value 1): Enable Video
+                                            * Bit 1 (value 2): Enable Audio
+                                            * Bit 2 (value 4): Use Fast Savestates.
+                                            * Bit 3 (value 8): Hard Disable Audio
+                                            * Other bits are reserved for future use and will default to zero.
+                                            * If video is disabled:
+                                            * * The frontend wants the core to not generate any video,
+                                            *   including presenting frames via hardware acceleration.
+                                            * * The frontend's video frame callback will do nothing.
+                                            * * After running the frame, the video output of the next frame should be
+                                            *   no different than if video was enabled, and saving and loading state
+                                            *   should have no issues.
+                                            * If audio is disabled:
+                                            * * The frontend wants the core to not generate any audio.
+                                            * * The frontend's audio callbacks will do nothing.
+                                            * * After running the frame, the audio output of the next frame should be
+                                            *   no different than if audio was enabled, and saving and loading state
+                                            *   should have no issues.
+                                            * Fast Savestates:
+                                            * * Guaranteed to be created by the same binary that will load them.
+                                            * * Will not be written to or read from the disk.
+                                            * * Suggest that the core assumes loading state will succeed.
+                                            * * Suggest that the core updates its memory buffers in-place if possible.
+                                            * * Suggest that the core skips clearing memory.
+                                            * * Suggest that the core skips resetting the system.
+                                            * * Suggest that the core may skip validation steps.
+                                            * Hard Disable Audio:
+                                            * * Used for a secondary core when running ahead.
+                                            * * Indicates that the frontend will never need audio from the core.
+                                            * * Suggests that the core may stop synthesizing audio, but this should not
+                                            *   compromise emulation accuracy.
+                                            * * Audio output for the next frame does not matter, and the frontend will
+                                            *   never need an accurate audio state in the future.
+                                            * * State will never be saved when using Hard Disable Audio.
+                                            */
 
 #define RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE (41 | RETRO_ENVIRONMENT_EXPERIMENTAL)
                                            /* const struct retro_hw_render_interface ** --
@@ -1841,6 +1886,10 @@ enum retro_hw_context_type
 
    /* Vulkan, see RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE. */
    RETRO_HW_CONTEXT_VULKAN           = 6,
+
+   /* Direct3D, set version_major to select the type of interface
+    * returned by RETRO_ENVIRONMENT_GET_HW_RENDER_INTERFACE */
+   RETRO_HW_CONTEXT_DIRECT3D         = 7,
 
    RETRO_HW_CONTEXT_DUMMY = INT_MAX
 };

--- a/nes_emu/Blip_Buffer.cpp
+++ b/nes_emu/Blip_Buffer.cpp
@@ -389,3 +389,18 @@ void Blip_Buffer::mix_samples( blip_sample_t const* in, long count )
 	}
 	*out -= prev;
 }
+
+void Blip_Buffer::SaveAudioBufferState()
+{
+	extra_length = length_;
+	extra_offset = offset_;
+	extra_reader_accum = reader_accum;
+	memcpy(extra_buffer, buffer_, sizeof(extra_buffer));
+}
+void Blip_Buffer::RestoreAudioBufferState()
+{
+	length_ = extra_length;
+	offset_ = extra_offset;
+	reader_accum = extra_reader_accum;
+	memcpy(buffer_, extra_buffer, sizeof(extra_buffer));
+}

--- a/nes_emu/Blip_Buffer.h
+++ b/nes_emu/Blip_Buffer.h
@@ -106,6 +106,16 @@ private:
 	int bass_freq_;
 	int length_;
 	friend class Blip_Reader;
+
+private:
+	//extra information necessary to load state to an exact sample
+	buf_t_ extra_buffer[32];
+	int extra_length;
+	long extra_reader_accum;
+	blip_resampled_time_t extra_offset;
+public:
+	void SaveAudioBufferState();
+	void RestoreAudioBufferState();
 };
 
 #ifdef HAVE_CONFIG_H

--- a/nes_emu/Mapper_Vrc7.cpp
+++ b/nes_emu/Mapper_Vrc7.cpp
@@ -32,7 +32,7 @@ struct vrc7_state_t
 	
 	vrc7_snapshot_t sound_state;
 };
-BOOST_STATIC_ASSERT( sizeof (vrc7_state_t) == 18 + sizeof (vrc7_snapshot_t) );
+BOOST_STATIC_ASSERT( sizeof (vrc7_state_t) == 20 + sizeof (vrc7_snapshot_t) );
 
 class Mapper_Vrc7 : public Nes_Mapper, vrc7_state_t {
 public:
@@ -63,7 +63,7 @@ public:
 		
 		next_time = get_le16( &next_time );
 		
-		sound.load_snapshot( sound_state );
+		sound.load_snapshot( sound_state, in.size );
 	}
 	
 	virtual void reset_state()

--- a/nes_emu/Multi_Buffer.h
+++ b/nes_emu/Multi_Buffer.h
@@ -64,6 +64,19 @@ private:
 	long sample_rate_;
 	int length_;
 	int const samples_per_frame_;
+	unsigned channels_changed_count_save_;
+protected:
+	void SaveAudioBufferStatePrivate()
+	{
+		channels_changed_count_save_ = channels_changed_count_;
+	}
+	void RestoreAudioBufferStatePrivate()
+	{
+		channels_changed_count_ = channels_changed_count_save_;
+	}
+public:
+	virtual void SaveAudioBufferState() = 0;
+	virtual void RestoreAudioBufferState() = 0;
 };
 
 // Uses a single buffer and outputs mono samples.
@@ -85,6 +98,18 @@ public:
 	void end_frame( blip_time_t, bool unused = true );
 	long samples_avail() const;
 	long read_samples( blip_sample_t*, long );
+
+	virtual void SaveAudioBufferState()
+	{
+		SaveAudioBufferStatePrivate();
+		center()->SaveAudioBufferState();
+	}
+	virtual void RestoreAudioBufferState()
+	{
+		RestoreAudioBufferStatePrivate();
+		center()->RestoreAudioBufferState();
+	}
+
 };
 
 // Uses three buffers (one for center) and outputs stereo sample pairs.
@@ -118,6 +143,22 @@ private:
 	
 	void mix_stereo( blip_sample_t*, long );
 	void mix_mono( blip_sample_t*, long );
+
+	virtual void SaveAudioBufferState()
+	{
+		SaveAudioBufferStatePrivate();
+		left()->SaveAudioBufferState();
+		center()->SaveAudioBufferState();
+		right()->SaveAudioBufferState();
+	}
+	virtual void RestoreAudioBufferState()
+	{
+		RestoreAudioBufferStatePrivate();
+		left()->RestoreAudioBufferState();
+		center()->RestoreAudioBufferState();
+		right()->RestoreAudioBufferState();
+	}
+
 };
 
 // Silent_Buffer generates no samples, useful where no sound is wanted
@@ -134,6 +175,15 @@ public:
 	void end_frame( blip_time_t, bool unused = true ) { }
 	long samples_avail() const { return 0; }
 	long read_samples( blip_sample_t*, long ) { return 0; }
+
+	virtual void SaveAudioBufferState()
+	{
+		SaveAudioBufferStatePrivate();
+	}
+	virtual void RestoreAudioBufferState()
+	{
+		RestoreAudioBufferStatePrivate();
+	}
 };
 
 

--- a/nes_emu/Nes_Buffer.h
+++ b/nes_emu/Nes_Buffer.h
@@ -18,6 +18,8 @@ private:
 	long accum;
 	long prev;
 	
+	long extra_accum;
+	long extra_prev;
 public:
 	Nes_Nonlinearizer();
 	bool enabled;
@@ -25,6 +27,16 @@ public:
 	void set_apu( Nes_Apu* a ) { apu = a; }
 	Nes_Apu* enable( bool, Blip_Buffer* tnd );
 	long make_nonlinear( Blip_Buffer& buf, long count );
+	void SaveAudioBufferState()
+	{
+		extra_accum = accum;
+		extra_prev = prev;
+	}
+	void RestoreAudioBufferState()
+	{
+		accum = extra_accum;
+		prev = extra_prev;
+	}
 };
 
 class Nes_Buffer : public Multi_Buffer {
@@ -58,6 +70,21 @@ private:
 	Blip_Buffer tnd;
 	Nes_Nonlinearizer nonlin;
 	friend Multi_Buffer* set_apu( Nes_Buffer*, Nes_Apu* );
+public:
+	virtual void SaveAudioBufferState()
+	{
+		SaveAudioBufferStatePrivate();
+		nonlin.SaveAudioBufferState();
+		buf.SaveAudioBufferState();
+		tnd.SaveAudioBufferState();
+	}
+	virtual void RestoreAudioBufferState()
+	{
+		RestoreAudioBufferStatePrivate();
+		nonlin.RestoreAudioBufferState();
+		buf.RestoreAudioBufferState();
+		tnd.RestoreAudioBufferState();
+	}
 };
 
 #endif

--- a/nes_emu/Nes_Emu.cpp
+++ b/nes_emu/Nes_Emu.cpp
@@ -27,9 +27,12 @@ int const sound_fade_size = 384;
 BOOST_STATIC_ASSERT( Nes_Emu::image_width  == 0 + Nes_Ppu::image_width );
 BOOST_STATIC_ASSERT( Nes_Emu::image_height == 0 + Nes_Ppu::image_height );
 
-Nes_Emu::equalizer_t const Nes_Emu::nes_eq     = {  -1.0,  80 };
-Nes_Emu::equalizer_t const Nes_Emu::famicom_eq = { -15.0,  80 };
-Nes_Emu::equalizer_t const Nes_Emu::tv_eq      = { -12.0, 180 };
+Nes_Emu::equalizer_t const Nes_Emu::nes_eq     = {  -1.0,   80 };
+Nes_Emu::equalizer_t const Nes_Emu::famicom_eq = { -15.0,   80 };
+Nes_Emu::equalizer_t const Nes_Emu::tv_eq      = { -12.0,  180 };
+Nes_Emu::equalizer_t const Nes_Emu::flat_eq    = {   0.0,    1 };
+Nes_Emu::equalizer_t const Nes_Emu::crisp_eq   = {   5.0,    1 };
+Nes_Emu::equalizer_t const Nes_Emu::tinny_eq   = { -47.0, 2000 };
 
 Nes_Emu::Nes_Emu()
 {
@@ -209,6 +212,7 @@ void Nes_Emu::load_state( Nes_State const& in )
 const char * Nes_Emu::load_state( Auto_File_Reader in )
 {
 	Nes_State* state = BLARGG_NEW Nes_State;
+	state->clear();  //initialize it
 	CHECK_ALLOC( state );
 	const char * err = state->read( in );
 	if ( !err )

--- a/nes_emu/Nes_Emu.h
+++ b/nes_emu/Nes_Emu.h
@@ -132,6 +132,9 @@ public:
 	static equalizer_t const nes_eq;        // NES
 	static equalizer_t const famicom_eq;    // Famicom
 	static equalizer_t const tv_eq;         // TV speaker
+	static equalizer_t const flat_eq;       // Flat EQ
+	static equalizer_t const crisp_eq;      // Crisp EQ (Treble boost)
+	static equalizer_t const tinny_eq;      // Tinny EQ (Like a handheld speaker)
 
 // File save/load
 
@@ -244,6 +247,26 @@ private:
 
 	bool init_called;
 	const char * auto_init();
+
+	bool extra_fade_sound_in;
+	bool extra_fade_sound_out;
+	unsigned extra_sound_buf_changed_count;
+public:
+	void SaveAudioBufferState()
+	{
+		extra_fade_sound_in = fade_sound_in;
+		extra_fade_sound_out = fade_sound_out;
+		extra_sound_buf_changed_count = sound_buf_changed_count;
+		sound_buf->SaveAudioBufferState();
+	}
+	void RestoreAudioBufferState()
+	{
+		fade_sound_in = extra_fade_sound_in;
+		fade_sound_out = extra_fade_sound_out;
+		sound_buf_changed_count = extra_sound_buf_changed_count;
+		sound_buf->RestoreAudioBufferState();
+	}
+
 };
 
 inline void Nes_Emu::set_pixels( void* p, long n )

--- a/nes_emu/Nes_Fme7_Apu.h
+++ b/nes_emu/Nes_Fme7_Apu.h
@@ -128,6 +128,9 @@ inline void Nes_Fme7_Apu::load_state( fme7_apu_state_t const& in )
 	reset();
 	fme7_apu_state_t* state = this;
 	*state = in;
+
+	//Run sound channels for 0 cycles for clean audio after loading state
+	run_until(last_time);
 }
 
 #endif

--- a/nes_emu/Nes_Vrc6_Apu.cpp
+++ b/nes_emu/Nes_Vrc6_Apu.cpp
@@ -99,6 +99,9 @@ void Nes_Vrc6_Apu::load_state( vrc6_apu_state_t const& in )
 	}
 	if ( !oscs [2].phase )
 		oscs [2].phase = 1;
+
+	//Run sound channels for 0 cycles for clean audio after loading state
+	this->run_until(this->last_time);
 }
 
 void Nes_Vrc6_Apu::run_square( Vrc6_Osc& osc, nes_time_t end_time )

--- a/nes_emu/Nes_Vrc7.h
+++ b/nes_emu/Nes_Vrc7.h
@@ -6,6 +6,8 @@
 #ifndef NES_VRC7_H
 #define NES_VRC7_H
 
+#include "emu2413_state.h"
+
 struct vrc7_snapshot_t;
 
 class Nes_Vrc7 {
@@ -21,9 +23,10 @@ public:
 	enum { osc_count = 6 };
 	void osc_output( int index, Blip_Buffer* );
 	void end_frame( nes_time_t );
-	void save_snapshot( vrc7_snapshot_t* ) const;
-	void load_snapshot( vrc7_snapshot_t const& );
-	
+	void save_snapshot(vrc7_snapshot_t*);
+	void load_snapshot(vrc7_snapshot_t &, int dataSize);
+	void update_last_amp();
+
 	void write_reg( int reg );
 	void write_data( nes_time_t, int data );
 	
@@ -55,8 +58,10 @@ struct vrc7_snapshot_t
 	uint8_t inst [8];
 	uint8_t regs [6] [3];
 	uint8_t count;
+	int internal_opl_state_size;
+	OPLL_STATE internal_opl_state;
 };
-BOOST_STATIC_ASSERT( sizeof (vrc7_snapshot_t) == 28 );
+BOOST_STATIC_ASSERT( sizeof (vrc7_snapshot_t) == 28 + 440 + 4 );
 
 inline void Nes_Vrc7::osc_output( int i, Blip_Buffer* buf )
 {

--- a/nes_emu/apu_state.cpp
+++ b/nes_emu/apu_state.cpp
@@ -129,4 +129,11 @@ void Nes_Apu::load_state( apu_state_t const& state )
 	refl::reflect_noise   ( st.noise,       noise );
 	refl::reflect_dmc     ( st.dmc,         dmc );
 	dmc.recalc_irq();
+
+	//force channels to have correct last_amp levels after load state
+	square1.run(last_time, last_time);
+	square2.run(last_time, last_time);
+	triangle.run(last_time, last_time);
+	noise.run(last_time, last_time);
+	dmc.run(last_time, last_time);
 }

--- a/nes_emu/emu2413_state.cpp
+++ b/nes_emu/emu2413_state.cpp
@@ -1,0 +1,107 @@
+#include "emu2413_state.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int OPLL_serialize_size()
+{
+	return sizeof(OPLL_STATE);
+}
+
+void OPLL_serialize(const OPLL * opll, OPLL_STATE* state)
+{
+	int i;
+
+	state->pm_phase = opll->pm_phase;
+	state->am_phase = opll->am_phase;
+
+	for (i = 0; i < 12; i++)
+	{
+		OPLL_SLOT_STATE *slotState = &(state->slot[i]);
+		const OPLL_SLOT *slot= &(opll->slot[i]);
+		slotState->feedback = slot->feedback;
+		slotState->output[0] = slot->output[0];
+		slotState->output[1] = slot->output[1];
+		slotState->phase = slot->phase;
+		slotState->pgout = slot->pgout;
+		slotState->eg_mode = slot->eg_mode;
+		slotState->eg_phase = slot->eg_phase;
+		slotState->eg_dphase = slot->eg_dphase;
+		slotState->egout = slot->egout;
+	}
+}
+
+#define BYTESWAP(xxxx) {uint32_t _temp = (uint32_t)(xxxx);\
+((uint8_t*)&(xxxx))[0] = (uint8_t)((_temp) >> 24);\
+((uint8_t*)&(xxxx))[1] = (uint8_t)((_temp) >> 16);\
+((uint8_t*)&(xxxx))[2] = (uint8_t)((_temp) >> 8);\
+((uint8_t*)&(xxxx))[3] = (uint8_t)((_temp) >> 0);\
+}
+
+
+#define SET(xxxx,yyyy) { if ((xxxx) != (yyyy)) {\
+(xxxx) = (yyyy);\
+}
+
+void OPLL_deserialize(OPLL * opll, const OPLL_STATE* state)
+{
+	int i;
+
+	opll->pm_phase = state->pm_phase;
+	opll->am_phase = state->am_phase;
+
+	for (i = 0; i < 12; i++)
+	{
+		const OPLL_SLOT_STATE *slotState = &(state->slot[i]);
+		OPLL_SLOT *slot = &(opll->slot[i]);
+		slot->feedback = slotState->feedback;
+		slot->output[0] = slotState->output[0];
+		slot->output[1] = slotState->output[1];
+		slot->phase = slotState->phase;
+		slot->pgout = slotState->pgout;
+		slot->eg_mode = slotState->eg_mode;
+		slot->eg_phase = slotState->eg_phase;
+		slot->eg_dphase = slotState->eg_dphase;
+		slot->egout = slotState->egout;
+	}
+}
+
+static bool IsLittleEndian()
+{
+	int i = 42;
+	if (((char*)&i)[0] == 42)
+	{
+		return true;
+	}
+	return false;
+}
+
+void OPLL_state_byteswap(OPLL_STATE *state)
+{
+	int i;
+	if (IsLittleEndian()) return;
+
+	BYTESWAP(state->pm_phase);
+	BYTESWAP(state->am_phase);
+
+	for (i = 0; i < 12; i++)
+	{
+		OPLL_SLOT_STATE *slotState = &(state->slot[i]);
+		BYTESWAP(slotState->feedback);
+		BYTESWAP(slotState->output[0]);
+		BYTESWAP(slotState->output[1]);
+		BYTESWAP(slotState->phase);
+		BYTESWAP(slotState->pgout);
+		BYTESWAP(slotState->eg_mode);
+		BYTESWAP(slotState->eg_phase);
+		BYTESWAP(slotState->eg_dphase);
+		BYTESWAP(slotState->egout);
+	}
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/nes_emu/emu2413_state.h
+++ b/nes_emu/emu2413_state.h
@@ -1,0 +1,37 @@
+#ifndef EMU2413_STATE_H
+#define EMU2413_STATE_H
+
+#include "emu2413.h"
+
+typedef struct {
+	e_int32 feedback;
+	e_int32 output[2];
+	e_uint32 phase;
+	e_uint32 pgout;
+	e_int32 eg_mode;
+	e_uint32 eg_phase;
+	e_uint32 eg_dphase;
+	e_uint32 egout;
+} OPLL_SLOT_STATE;
+
+typedef struct {
+	e_uint32 pm_phase;
+	e_int32 am_phase;
+	OPLL_SLOT_STATE slot[6 * 2];
+} OPLL_STATE;
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+int OPLL_serialize_size();
+void OPLL_serialize(const OPLL * opll, OPLL_STATE* state);
+void OPLL_deserialize(OPLL * opll, const OPLL_STATE* state);
+void OPLL_state_byteswap(OPLL_STATE *state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/nes_emu/nes_data.h
+++ b/nes_emu/nes_data.h
@@ -80,7 +80,7 @@ BOOST_STATIC_ASSERT( sizeof (joypad_state_t) == 12 );
 
 // Increase this (and let me know) if your mapper requires more state. This only
 // sets the size of the in-memory buffer; it doesn't affect the file format at all.
-unsigned const max_mapper_state_size = 256;
+unsigned const max_mapper_state_size = 512;   //was 256, needed more for VRC7 audio state
 struct mapper_state_t
 {
 	int size;


### PR DESCRIPTION
* Clean audio when saving and loading state at zero Run-Ahead frames, via saving and restoring the audio buffer state.
* Clean audio when saving and loading state for Konami VRC7 sound
* Select between Nonlinear and Linear mixer mode.  Nonlinear is more accurate to hardware, but Linear has louder DMC samples.
* Select between audio EQ modes: "Nes" (default), "Famicom" (treble diminished), "TV", "Flat" (minimal eq), "Crisp" (treble boost), and "Tinny" (treble and bass diminished).
* Nonlinear mixer mode has been made the default mixing mode.  It sounds different than Linear, has quieter DMC samples, and may sound worse in some cases, but is truer to actual hardware.
* APU channels and Mapper audio now apply their initial volume levels to the output buffer immediately when loading state.
* Fixed a bug where loading state did not initialize some variables