### PR TITLE
Code Cleanup and Audio/Video Disable support

### DIFF
--- a/nes_emu/Multi_Buffer.cpp
+++ b/nes_emu/Multi_Buffer.cpp
@@ -21,11 +21,22 @@ Multi_Buffer::Multi_Buffer( int spf ) : samples_per_frame_( spf )
 	length_ = 0;
 	sample_rate_ = 0;
 	channels_changed_count_ = 1;
+	channels_changed_count_save_ = 1;
 }
 
 const char * Multi_Buffer::set_channel_count( int )
 {
 	return 0;
+}
+
+void Multi_Buffer::SaveAudioBufferStatePrivate()
+{
+	channels_changed_count_save_ = channels_changed_count_;
+}
+
+void Multi_Buffer::RestoreAudioBufferStatePrivate()
+{
+	channels_changed_count_ = channels_changed_count_save_;
 }
 
 Mono_Buffer::Mono_Buffer() : Multi_Buffer( 1 )
@@ -42,6 +53,18 @@ const char * Mono_Buffer::set_sample_rate( long rate, int msec )
 	return Multi_Buffer::set_sample_rate( buf.sample_rate(), buf.length() );
 }
 
+void Mono_Buffer::SaveAudioBufferState()
+{
+	SaveAudioBufferStatePrivate();
+	center()->SaveAudioBufferState();
+}
+
+void Mono_Buffer::RestoreAudioBufferState()
+{
+	RestoreAudioBufferStatePrivate();
+	center()->RestoreAudioBufferState();
+}
+
 // Silent_Buffer
 
 Silent_Buffer::Silent_Buffer() : Multi_Buffer( 1 ) // 0 channels would probably confuse
@@ -49,6 +72,16 @@ Silent_Buffer::Silent_Buffer() : Multi_Buffer( 1 ) // 0 channels would probably 
 	chan.left   = NULL;
 	chan.center = NULL;
 	chan.right  = NULL;
+}
+
+void Silent_Buffer::SaveAudioBufferState()
+{
+	SaveAudioBufferStatePrivate();
+}
+
+void Silent_Buffer::RestoreAudioBufferState()
+{
+	RestoreAudioBufferStatePrivate();
 }
 
 // Mono_Buffer
@@ -162,24 +195,37 @@ void Stereo_Buffer::mix_stereo( blip_sample_t* out, long count )
 	right.begin( bufs [2] );
 	int bass = center.begin( bufs [0] );
 	
-	while ( count-- )
+	if (out != NULL)
 	{
-		int c = center.read();
-		long l = c + left.read();
-		long r = c + right.read();
-		center.next( bass );
-		out [0] = l;
-		out [1] = r;
-		out += 2;
+		while ( count-- )
+		{
+			int c = center.read();
+			long l = c + left.read();
+			long r = c + right.read();
+			center.next( bass );
+			out [0] = l;
+			out [1] = r;
+			out += 2;
 		
-		if ( (int16_t) l != l )
-			out [-2] = 0x7FFF - (l >> 24);
+			if ( (int16_t) l != l )
+				out [-2] = 0x7FFF - (l >> 24);
 		
-		left.next( bass );
-		right.next( bass );
+			left.next( bass );
+			right.next( bass );
 		
-		if ( (int16_t) r != r )
-			out [-1] = 0x7FFF - (r >> 24);
+			if ( (int16_t) r != r )
+				out [-1] = 0x7FFF - (r >> 24);
+		}
+	}
+	else
+	{
+		//only run accumulators, do not output any audio
+		while (count--)
+		{
+			center.next(bass);
+			left.next(bass);
+			right.next(bass);
+		}
 	}
 	
 	center.end( bufs [0] );
@@ -192,20 +238,45 @@ void Stereo_Buffer::mix_mono( blip_sample_t* out, long count )
 	Blip_Reader in;
 	int bass = in.begin( bufs [0] );
 	
-	while ( count-- )
+	if (out != NULL)
 	{
-		long s = in.read();
-		in.next( bass );
-		out [0] = s;
-		out [1] = s;
-		out += 2;
+		while ( count-- )
+		{
+			long s = in.read();
+			in.next( bass );
+			out [0] = s;
+			out [1] = s;
+			out += 2;
 		
-		if ( (int16_t) s != s ) {
-			s = 0x7FFF - (s >> 24);
-			out [-2] = s;
-			out [-1] = s;
+			if ( (int16_t) s != s ) {
+				s = 0x7FFF - (s >> 24);
+				out [-2] = s;
+				out [-1] = s;
+			}
+		}
+	}
+	else
+	{
+		while (count--)
+		{
+			in.next(bass);
 		}
 	}
 	
 	in.end( bufs [0] );
+}
+
+void Stereo_Buffer::SaveAudioBufferState()
+{
+	SaveAudioBufferStatePrivate();
+	left()->SaveAudioBufferState();
+	center()->SaveAudioBufferState();
+	right()->SaveAudioBufferState();
+}
+void Stereo_Buffer::RestoreAudioBufferState()
+{
+	RestoreAudioBufferStatePrivate();
+	left()->RestoreAudioBufferState();
+	center()->RestoreAudioBufferState();
+	right()->RestoreAudioBufferState();
 }

--- a/nes_emu/Multi_Buffer.h
+++ b/nes_emu/Multi_Buffer.h
@@ -66,14 +66,8 @@ private:
 	int const samples_per_frame_;
 	unsigned channels_changed_count_save_;
 protected:
-	void SaveAudioBufferStatePrivate()
-	{
-		channels_changed_count_save_ = channels_changed_count_;
-	}
-	void RestoreAudioBufferStatePrivate()
-	{
-		channels_changed_count_ = channels_changed_count_save_;
-	}
+	void SaveAudioBufferStatePrivate();
+	void RestoreAudioBufferStatePrivate();
 public:
 	virtual void SaveAudioBufferState() = 0;
 	virtual void RestoreAudioBufferState() = 0;
@@ -99,17 +93,8 @@ public:
 	long samples_avail() const;
 	long read_samples( blip_sample_t*, long );
 
-	virtual void SaveAudioBufferState()
-	{
-		SaveAudioBufferStatePrivate();
-		center()->SaveAudioBufferState();
-	}
-	virtual void RestoreAudioBufferState()
-	{
-		RestoreAudioBufferStatePrivate();
-		center()->RestoreAudioBufferState();
-	}
-
+	virtual void SaveAudioBufferState();
+	virtual void RestoreAudioBufferState();
 };
 
 // Uses three buffers (one for center) and outputs stereo sample pairs.
@@ -144,21 +129,8 @@ private:
 	void mix_stereo( blip_sample_t*, long );
 	void mix_mono( blip_sample_t*, long );
 
-	virtual void SaveAudioBufferState()
-	{
-		SaveAudioBufferStatePrivate();
-		left()->SaveAudioBufferState();
-		center()->SaveAudioBufferState();
-		right()->SaveAudioBufferState();
-	}
-	virtual void RestoreAudioBufferState()
-	{
-		RestoreAudioBufferStatePrivate();
-		left()->RestoreAudioBufferState();
-		center()->RestoreAudioBufferState();
-		right()->RestoreAudioBufferState();
-	}
-
+	virtual void SaveAudioBufferState();
+	virtual void RestoreAudioBufferState();
 };
 
 // Silent_Buffer generates no samples, useful where no sound is wanted
@@ -176,14 +148,8 @@ public:
 	long samples_avail() const { return 0; }
 	long read_samples( blip_sample_t*, long ) { return 0; }
 
-	virtual void SaveAudioBufferState()
-	{
-		SaveAudioBufferStatePrivate();
-	}
-	virtual void RestoreAudioBufferState()
-	{
-		RestoreAudioBufferStatePrivate();
-	}
+	virtual void SaveAudioBufferState();
+	virtual void RestoreAudioBufferState();
 };
 
 

--- a/nes_emu/Nes_Buffer.h
+++ b/nes_emu/Nes_Buffer.h
@@ -27,16 +27,8 @@ public:
 	void set_apu( Nes_Apu* a ) { apu = a; }
 	Nes_Apu* enable( bool, Blip_Buffer* tnd );
 	long make_nonlinear( Blip_Buffer& buf, long count );
-	void SaveAudioBufferState()
-	{
-		extra_accum = accum;
-		extra_prev = prev;
-	}
-	void RestoreAudioBufferState()
-	{
-		accum = extra_accum;
-		prev = extra_prev;
-	}
+	void SaveAudioBufferState();
+	void RestoreAudioBufferState();
 };
 
 class Nes_Buffer : public Multi_Buffer {
@@ -71,20 +63,8 @@ private:
 	Nes_Nonlinearizer nonlin;
 	friend Multi_Buffer* set_apu( Nes_Buffer*, Nes_Apu* );
 public:
-	virtual void SaveAudioBufferState()
-	{
-		SaveAudioBufferStatePrivate();
-		nonlin.SaveAudioBufferState();
-		buf.SaveAudioBufferState();
-		tnd.SaveAudioBufferState();
-	}
-	virtual void RestoreAudioBufferState()
-	{
-		RestoreAudioBufferStatePrivate();
-		nonlin.RestoreAudioBufferState();
-		buf.RestoreAudioBufferState();
-		tnd.RestoreAudioBufferState();
-	}
+	virtual void SaveAudioBufferState();
+	virtual void RestoreAudioBufferState();
 };
 
 #endif

--- a/nes_emu/Nes_Emu.h
+++ b/nes_emu/Nes_Emu.h
@@ -52,6 +52,10 @@ public:
 	// and sound are available for output using the accessors below.
 	virtual const char * emulate_frame( int joypad1, int joypad2 = 0 );
 
+	// Emulate one video frame using joypad1 and joypad2 as input, but skips drawing.
+	// Afterwards, audio is available for output using the accessors below.
+	virtual const char * emulate_skip_frame( int joypad1, int joypad2 = 0 );
+
 	// Maximum size of palette that can be generated
 	enum { max_palette_size = 256 };
 
@@ -252,21 +256,8 @@ private:
 	bool extra_fade_sound_out;
 	unsigned extra_sound_buf_changed_count;
 public:
-	void SaveAudioBufferState()
-	{
-		extra_fade_sound_in = fade_sound_in;
-		extra_fade_sound_out = fade_sound_out;
-		extra_sound_buf_changed_count = sound_buf_changed_count;
-		sound_buf->SaveAudioBufferState();
-	}
-	void RestoreAudioBufferState()
-	{
-		fade_sound_in = extra_fade_sound_in;
-		fade_sound_out = extra_fade_sound_out;
-		sound_buf_changed_count = extra_sound_buf_changed_count;
-		sound_buf->RestoreAudioBufferState();
-	}
-
+	void SaveAudioBufferState();
+	void RestoreAudioBufferState();
 };
 
 inline void Nes_Emu::set_pixels( void* p, long n )

--- a/nes_emu/emu2413.cpp
+++ b/nes_emu/emu2413.cpp
@@ -883,7 +883,6 @@ static INLINE e_int16 calc (OPLL * opll)
 
 static INLINE void run (OPLL * opll)
 {
-  e_int32 inst = 0, out = 0;
   e_int32 i;
 
   update_ampm (opll);


### PR DESCRIPTION
* Implemented hard audio disable by switching to the silent_buffer
* Implemented frameskip by exposing the already built-in frameskip feature
* Supports outputting audio to a NULL buffer, this runs the audio accumulators without outputting anything and gets the next frame ready for outputting clean audio
* Code cleanup, moved some function definitions out of the header files, and initialized some uninitialized variables
* Remove an unused variable warning from emu2413.cpp