### PR TITLE
Support for more mappers, Add Namco106 sound states

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -51,4 +51,22 @@ SOURCES_CXX := \
 	$(CORE_DIR)/nes_emu/Nes_State.cpp \
 	$(CORE_DIR)/nes_emu/nes_util.cpp \
 	$(CORE_DIR)/nes_emu/Nes_Vrc6_Apu.cpp \
-	$(CORE_DIR)/nes_emu/Data_Reader.cpp
+	$(CORE_DIR)/nes_emu/Data_Reader.cpp \
+	$(CORE_DIR)/nes_emu/Mappers.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_74x161x162x32.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_180.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_193.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_240.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_241.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_244.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_246.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_AveNina.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_IremG101.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_IremTamS1.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_JalecoJF11.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_Namco54xx.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_Sunsoft1.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_Sunsoft2.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_TaitoX1005.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_TaitoTC0190.cpp \
+	$(CORE_DIR)/nes_emu/Mapper_Un1rom.cpp

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -149,7 +149,7 @@ void retro_set_video_refresh(retro_video_refresh_t cb)
 void retro_reset(void)
 {
    if (emu)
-      emu->reset();
+      emu->reset( false, false );
 }
 
 static void update_audio_mode(void)
@@ -509,6 +509,7 @@ bool retro_load_game(const struct retro_game_info *info)
 
    emu = new Nes_Emu;
    register_optional_mappers();
+   register_extra_mappers();
 
    check_variables();
 

--- a/nes_emu/Mapper_180.cpp
+++ b/nes_emu/Mapper_180.cpp
@@ -1,0 +1,55 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ * 
+ * Mapper 180 Crazy Climber
+ *
+ */
+
+#include "Nes_Mapper.h"
+ 
+class Mapper_180 : public Nes_Mapper {
+public:
+	Mapper_180()
+	{
+		register_state( &bank, 1 );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		set_prg_bank( 0x8000, bank_16k, 0 );
+		write( 0, 0, bank );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t, int data )
+	{
+		bank = data;
+		set_prg_bank( 0xC000, bank_16k, data );
+	}
+
+	uint8_t bank;
+};
+
+void register_mapper_180();
+void register_mapper_180()
+{
+	register_mapper< Mapper_180 > ( 180 );
+}

--- a/nes_emu/Mapper_193.cpp
+++ b/nes_emu/Mapper_193.cpp
@@ -1,0 +1,75 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 193 - NTDEC TC-112
+ * Fighting Hero (Unl)
+ * War in the Gulf & (its Brazilian localization)
+ *
+ */
+
+#include "Nes_Mapper.h"
+ 
+class Mapper_193 : public Nes_Mapper {
+public:
+	Mapper_193()
+	{
+		register_state( regs, sizeof regs );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		for ( int i = 0; i < sizeof regs; i++ )
+			write_intercepted( 0, 0x6000 + i, regs [ i ] );
+		set_prg_bank( 0xA000, bank_8k, ~2 );
+		set_prg_bank( 0xC000, bank_8k, ~1 );
+		set_prg_bank( 0xE000, bank_8k, ~0 );
+		intercept_writes( 0x6000, 0x03 );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{ }
+
+	virtual bool write_intercepted( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( addr < 0x6000 || addr > 0x6003 )
+			return false;
+
+		regs [ addr & 0x03 ] = data;
+		switch ( addr & 0x03 )
+		{
+		case 0: set_chr_bank( 0x0000, bank_4k, regs [ 0 ] >> 2 ); break;
+		case 1: set_chr_bank( 0x1000, bank_2k, regs [ 1 ] >> 1 ); break;
+		case 2: set_chr_bank( 0x1800, bank_2k, regs [ 2 ] >> 1 ); break;
+		case 3: set_prg_bank( 0x8000, bank_8k, regs [ 3 ] ); break;
+		}
+
+		return true;
+	}
+
+	uint8_t regs [ 4 ];
+};
+
+void register_mapper_193();
+void register_mapper_193()
+{
+	register_mapper< Mapper_193 > ( 193 );
+}

--- a/nes_emu/Mapper_240.cpp
+++ b/nes_emu/Mapper_240.cpp
@@ -1,0 +1,64 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ */
+
+#include "Nes_Mapper.h"
+
+class Mapper_240 : public Nes_Mapper {
+public:
+	Mapper_240()
+	{
+		register_state( &regs, 1 );
+	}
+
+	virtual void reset_state()
+	{
+	}
+
+	virtual void apply_mapping()
+	{
+		enable_sram();
+		intercept_writes( 0x4020, 1 );
+		write_intercepted( 0, 0x4120, regs );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t, int data )
+	{ }
+
+	virtual bool write_intercepted( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( addr < 0x4020 || addr > 0x5FFF )
+			return false;
+
+		regs = data;
+		set_chr_bank( 0x0000, bank_8k, data & 0x0F );
+		set_prg_bank( 0x8000, bank_32k, data >> 4 );
+
+		return true;
+	}
+
+	uint8_t regs;
+};
+
+void register_mapper_240();
+void register_mapper_240()
+{
+	register_mapper< Mapper_240 > ( 240 );
+}

--- a/nes_emu/Mapper_241.cpp
+++ b/nes_emu/Mapper_241.cpp
@@ -1,0 +1,53 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ */
+
+#include "Nes_Mapper.h"
+ 
+class Mapper_241 : public Nes_Mapper {
+public:
+	Mapper_241()
+	{
+		register_state( &bank, 1 );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		enable_sram();
+		write( 0, 0, bank );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t, int data )
+	{
+		bank = data;
+		set_prg_bank( 0x8000, bank_32k, bank );
+	}
+
+	uint8_t bank;
+};
+
+void register_mapper_241();
+void register_mapper_241()
+{
+	register_mapper< Mapper_241 > ( 241 );
+}

--- a/nes_emu/Mapper_244.cpp
+++ b/nes_emu/Mapper_244.cpp
@@ -1,0 +1,71 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 244 - Decathlon
+ *
+ */
+
+#include "Nes_Mapper.h"
+
+struct mapper244_state_t
+{
+	uint8_t preg;
+	uint8_t creg;
+};
+
+BOOST_STATIC_ASSERT( sizeof (mapper244_state_t) == 2 );
+
+class Mapper_244 : public Nes_Mapper, mapper244_state_t {
+public:
+	Mapper_244()
+	{
+		mapper244_state_t *state = this;
+		register_state( state, sizeof *state );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		set_prg_bank( 0x8000, bank_32k, preg );
+		set_chr_bank( 0x0000, bank_8k, creg );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( addr >= 0x8065 && addr <= 0x80A4 )
+		{
+			preg = ( addr - 0x8065 ) & 0x03;
+			set_prg_bank( 0x8000, bank_32k, preg );
+		}
+
+		if ( addr >= 0x80A5 && addr <= 0x80E4 )
+		{
+			creg = (addr - 0x80A5 ) & 0x07;
+			set_chr_bank( 0x0000, bank_8k, creg );
+		}
+	}
+};
+
+void register_mapper_244();
+void register_mapper_244()
+{
+	register_mapper< Mapper_244 > ( 244 );
+}

--- a/nes_emu/Mapper_246.cpp
+++ b/nes_emu/Mapper_246.cpp
@@ -1,0 +1,75 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 246 - Feng Shen Bang (Asia) (Ja) (Unl)
+ *
+ */
+
+#include "Nes_Mapper.h"
+
+class Mapper_246 : public Nes_Mapper {
+public:
+	Mapper_246()
+	{
+		register_state( regs, sizeof regs );
+	}
+
+	virtual void reset_state()
+	{
+		regs [ 3 ] = ~0;
+	}
+
+	virtual void apply_mapping()
+	{
+		enable_sram();
+		intercept_writes( 0x6000, 0x07 );
+		for ( int i = 0; i < sizeof regs; i++ )
+			write_intercepted( 0, 0x6000 + i, regs [ i ] );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{ }
+
+	virtual bool write_intercepted( nes_time_t, nes_addr_t addr, int data )
+	{
+		int bank = addr & 0x07;
+
+		if ( addr < 0x6000 || addr > 0x67FF )
+			return false;
+
+		regs [ bank ] = data;
+		if ( bank < 4 )
+		{
+			set_prg_bank( 0x8000 + ( bank << 13 ), bank_8k, data );
+			return true;
+		}
+
+		set_chr_bank( 0x0000 + ( ( bank & 0x03 ) << 11 ) , bank_2k, data );
+
+		return true;
+	}
+
+	uint8_t regs [ 8 ];
+};
+
+void register_mapper_246();
+void register_mapper_246()
+{
+	register_mapper< Mapper_246 > ( 246 );
+}

--- a/nes_emu/Mapper_74x161x162x32.cpp
+++ b/nes_emu/Mapper_74x161x162x32.cpp
@@ -1,0 +1,81 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 180 Crazy Climber
+ *
+ */
+
+#include "Nes_Mapper.h"
+
+template < bool _is152 >
+class Mapper_74x161x162x32 : public Nes_Mapper {
+public:
+	Mapper_74x161x162x32()
+	{
+		register_state( &bank, 1 );
+	}
+
+	virtual void reset_state()
+	{
+		if ( _is152 == 0 )
+			bank = ~0;
+	}
+
+	virtual void apply_mapping()
+	{
+		if ( _is152 )
+			write( 0, 0, bank );
+		else
+		{
+			intercept_writes( 0x6000, 1 );
+			write_intercepted( 0, 0x6000, bank );
+		}
+	}
+
+	virtual bool write_intercepted( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( ( addr != 0x6000 ) || _is152 )
+			return false;
+
+		bank = data;
+		set_prg_bank( 0x8000, bank_32k, ( bank >> 4 ) & 0x03 );
+		set_chr_bank( 0x0000, bank_8k, ( ( bank >> 4 ) & 0x04 ) | ( bank & 0x03 ) );
+
+		return true;
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( _is152 == 0) return;
+
+		bank = handle_bus_conflict (addr, data );
+		set_prg_bank( 0x8000, bank_16k, ( bank >> 4 ) & 0x07 );
+		set_chr_bank( 0x0000, bank_8k, bank & 0x0F );
+		mirror_single( ( bank >> 7) & 0x01 );
+	}
+
+	uint8_t bank;
+};
+
+void register_mapper_74x161x162x32();
+void register_mapper_74x161x162x32()
+{
+	register_mapper< Mapper_74x161x162x32 <true> > ( 152 );
+	register_mapper< Mapper_74x161x162x32 <false> > ( 86 );
+}

--- a/nes_emu/Mapper_AveNina.cpp
+++ b/nes_emu/Mapper_AveNina.cpp
@@ -1,0 +1,93 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 079
+ * Mapper 113
+ * Nina-03 / Nina-06
+ */
+
+#include "Nes_Mapper.h"
+
+template < bool multicart >
+class Mapper_AveNina : public Nes_Mapper {
+public:
+	Mapper_AveNina()
+	{
+		register_state( &regs, 1 );
+	}
+
+	void write_regs();
+
+	virtual void reset_state()
+	{
+		intercept_writes( 0x4000, 0x1000 );
+		intercept_writes( 0x5000, 0x1000 );
+	}
+
+	virtual void apply_mapping()
+	{
+		write_intercepted( 0, 0x4100, regs );
+	}
+
+	virtual bool write_intercepted( nes_time_t, nes_addr_t addr , int data )
+	{
+		if ( addr < 0x4100 || addr > 0x5FFF )
+			return false;
+
+		 if ( addr & 0x100 )
+			regs = data;
+
+		write_regs();
+		return true;
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( multicart == 0 &&
+			( ( addr == 0x8000 ) || ( addr & 0xFCB0 ) == 0xFCB0 ) )
+				set_chr_bank( 0, bank_8k, data & 0x07 );
+	}
+
+	uint8_t regs;
+};
+
+template < bool multicart >
+void Mapper_AveNina< multicart >::write_regs()
+{
+	if ( multicart == 0 )
+	{
+		set_prg_bank ( 0x8000, bank_32k, ( regs >> 3 ) & 0x01 );
+		set_chr_bank ( 0, bank_8k, regs & 0x07 );
+	}
+	else
+	{
+		set_prg_bank ( 0x8000, bank_32k, ( regs >> 3 ) & 0x07 );
+		set_chr_bank ( 0x0000, bank_8k, ( ( regs >> 3 ) & 0x08 ) | ( regs & 0x07 ) );
+		if ( regs & 0x80 ) mirror_vert();
+		else mirror_horiz();
+	}
+}
+
+void register_mapper_avenina();
+void register_mapper_avenina()
+{
+	register_mapper < Mapper_AveNina < false > > ( 79 );
+	register_mapper < Mapper_AveNina < true  > > ( 113 );
+}

--- a/nes_emu/Mapper_IremG101.cpp
+++ b/nes_emu/Mapper_IremG101.cpp
@@ -1,0 +1,120 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 32 - Irem's G-101
+ *
+ */
+
+#include "Nes_Mapper.h"
+
+struct mapper32_state_t
+{
+	uint8_t chr_bank [ 8 ];
+	uint8_t prg_bank [ 2 ];
+	uint8_t prg_mode;
+	uint8_t mirr;
+};
+
+BOOST_STATIC_ASSERT( sizeof ( mapper32_state_t ) == 12 );
+
+class Mapper_Irem_G101 : public Nes_Mapper, mapper32_state_t {
+public:
+	Mapper_Irem_G101()
+	{
+		mapper32_state_t * state = this;
+		register_state( state, sizeof * state );
+	}
+
+	virtual void reset_state()
+	{
+		prg_bank [ 0 ] = ~1;
+		prg_bank [ 1 ] = ~0;
+		enable_sram();
+	}
+
+	virtual void apply_mapping()
+	{
+		if ( prg_mode == 0 )
+		{
+			set_prg_bank ( 0x8000, bank_8k, prg_bank [ 0 ] );
+			set_prg_bank ( 0xA000, bank_8k, prg_bank [ 1 ] );
+			set_prg_bank ( 0xC000, bank_8k, ~1 );
+			set_prg_bank ( 0xE000, bank_8k, ~0 );
+		}
+		else
+		{
+			set_prg_bank ( 0xC000, bank_8k, prg_bank [ 0 ] );
+			set_prg_bank ( 0xA000, bank_8k, prg_bank [ 1 ] );
+			set_prg_bank ( 0x8000, bank_8k, ~1 );
+			set_prg_bank ( 0xE000, bank_8k, ~0 );
+		}
+
+		for ( int i = 0; i < sizeof chr_bank; i++)
+			set_chr_bank( ( i << 10 ), bank_1k, chr_bank [ i ] );
+
+		switch ( mirr )
+		{
+		case 0: mirror_vert(); break;
+		case 1: mirror_horiz(); break;
+		}
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		switch ( addr & 0xF000 )
+		{
+		case 0x8000:
+			prg_bank [ 0 ] = data;
+			switch ( prg_mode )
+			{
+			case 0: set_prg_bank ( 0x8000, bank_8k, data ); break;
+			case 1: set_prg_bank ( 0xC000, bank_8k, data ); break;
+			}
+			break;
+		case 0x9000:
+			mirr = data & 1;
+			prg_mode = ( data >> 1 ) & 1;
+			switch ( data & 1 )
+			{
+			case 0: mirror_vert(); break;
+			case 1: mirror_horiz(); break;
+			}
+			break;
+		case 0xA000:
+			prg_bank [ 1 ] = data;
+			set_prg_bank ( 0xA000, bank_8k, data );
+			break;
+		}
+
+		switch ( addr & 0xF007 )
+		{
+		case 0xB000: case 0xB001: case 0xB002: case 0xB003:
+		case 0xB004: case 0xB005: case 0xB006: case 0xB007:
+			chr_bank [ addr & 0x07 ] = data;
+			set_chr_bank( ( addr & 0x07 ) << 10, bank_1k, data );
+			break;
+		}
+	}
+};
+
+void register_mapper_irem_g101();
+void register_mapper_irem_g101()
+{
+	register_mapper< Mapper_Irem_G101 > ( 32 );
+}

--- a/nes_emu/Mapper_IremTamS1.cpp
+++ b/nes_emu/Mapper_IremTamS1.cpp
@@ -1,0 +1,65 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ * 
+ * Mapper 97 - Kaiketsu Yanchamaru
+ *
+ */
+
+#include "Nes_Mapper.h"
+ 
+class Mapper_Irem_Tam_S1 : public Nes_Mapper {
+public:
+	Mapper_Irem_Tam_S1()
+	{
+		register_state( &bank, 1 );
+	}
+
+	virtual void reset_state()
+	{
+		bank = ~0;
+	}
+
+	virtual void apply_mapping()
+	{
+		write( 0, 0, bank );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t, int data )
+	{
+		bank = data;
+		set_prg_bank( 0x8000, bank_16k, ~0 );
+		set_prg_bank( 0xC000, bank_16k, bank & 0x0F );
+
+		switch ( ( bank >> 6 ) & 0x03 )
+		{
+		case 1: mirror_horiz(); break;
+		case 2: mirror_vert(); break;
+		case 0:
+		case 3: mirror_single( bank & 0x01 ); break;
+		}
+	}
+
+	uint8_t bank;
+};
+
+void register_mapper_irem_tamS1();
+void register_mapper_irem_tamS1()
+{
+	register_mapper< Mapper_Irem_Tam_S1 > ( 97 );
+}

--- a/nes_emu/Mapper_JalecoJF11.cpp
+++ b/nes_emu/Mapper_JalecoJF11.cpp
@@ -1,0 +1,65 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301, USA.
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 140 - Jaleco's JF-11 and JF-14
+ *
+ */
+
+#include "Nes_Mapper.h"
+
+class Mapper_Jaleco_JF11 : public Nes_Mapper {
+public:
+	Mapper_Jaleco_JF11()
+	{
+		register_state( &regs, 1 );
+	}
+
+	virtual void reset_state()
+	{
+		intercept_writes( 0x6000, 1 );
+	}
+
+	virtual void apply_mapping()
+	{
+		write_intercepted(0, 0x6000, regs );
+	}
+
+	bool write_intercepted( nes_time_t time, nes_addr_t addr, int data )
+	{
+		if ( addr < 0x6000 || addr > 0x7FFF )
+			return false;
+
+		regs = data;
+		set_prg_bank( 0x8000, bank_32k, data >> 4);
+		set_chr_bank( 0, bank_8k, data );
+
+		return true;
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data ) { }
+
+	uint8_t regs;
+};
+
+void register_mapper_jaleco_jf11();
+void register_mapper_jaleco_jf11()
+{
+	register_mapper< Mapper_Jaleco_JF11 > ( 140 );
+}

--- a/nes_emu/Mapper_Namco106.cpp
+++ b/nes_emu/Mapper_Namco106.cpp
@@ -5,6 +5,7 @@
 
 #include "Nes_Mapper.h"
 
+#include "blargg_endian.h"
 #include "Nes_Namco_Apu.h"
 
 /* Copyright (C) 2004-2006 Shay Green. This module is free software; you
@@ -27,9 +28,12 @@ struct namco106_state_t
 	uint8_t regs [16];
 	uint16_t irq_ctr;
 	uint8_t irq_pending;
-	uint8_t unused1 [1]; 
+	uint8_t unused1 [1];
+	namco_state_t sound_state;
+	void swap();
 };
-BOOST_STATIC_ASSERT( sizeof (namco106_state_t) == 20 );
+
+BOOST_STATIC_ASSERT( sizeof (namco106_state_t) == 20 + sizeof (namco_state_t) );
 
 class Mapper_Namco106 : public Nes_Mapper, namco106_state_t {
 	Nes_Namco_Apu sound;
@@ -40,13 +44,17 @@ public:
 		namco106_state_t* state = this;
 		register_state( state, sizeof *state );
 	}
-	
+
 	virtual int channel_count() const { return sound.osc_count; }
-	
+
 	virtual void set_channel_buf( int i, Blip_Buffer* b ) { sound.osc_output( i, b ); }
-	
+
 	virtual void set_treble( blip_eq_t const& eq ) { sound.treble_eq( eq ); }
-	
+
+	virtual void save_state( mapper_state_t& out );
+
+	virtual void read_state( mapper_state_t const& in );
+
 	void reset_state()
 	{
 		regs [12] = 0;
@@ -54,32 +62,32 @@ public:
 		regs [14] = last_bank - 1;
 		sound.reset();
 	}
-	
+
 	virtual void apply_mapping()
 	{
 		last_time = 0;
 		enable_sram();
 		intercept_writes( 0x4800, 1 );
 		intercept_reads ( 0x4800, 1 );
-		
+
 		intercept_writes( 0x5000, 0x1000 );
 		intercept_reads ( 0x5000, 0x1000 );
-		
+
 		for ( int i = 0; i < (int) sizeof regs; i++ )
 			write( 0, 0x8000 + i * 0x800, regs [i] );
 	}
-	
+
 	virtual nes_time_t next_irq( nes_time_t time )
 	{
 		if ( irq_pending )
 			return time;
-		
+
 		if ( !(irq_ctr & 0x8000) )
 			return no_irq;
-		
+
 		return 0x10000 - irq_ctr + last_time;
 	}
-	
+
 	virtual void run_until( nes_time_t end_time )
 	{
 		long count = irq_ctr + (end_time - last_time);
@@ -95,11 +103,11 @@ public:
 		{
 			count = 0x7fff;
 		}
-		
+
 		irq_ctr = count;
 		last_time = end_time;
 	}
-	
+
 	virtual void end_frame( nes_time_t end_time )
 	{
 		if ( end_time > last_time )
@@ -107,30 +115,30 @@ public:
 		last_time -= end_time;
 		sound.end_frame( end_time );
 	}
-	
+
 	void write_bank( nes_addr_t, int data );
 	void write_irq( nes_time_t, nes_addr_t, int data );
-	
+
 	virtual int read( nes_time_t time, nes_addr_t addr )
 	{
 		if ( addr == 0x4800 )
 			return sound.read_data();
-		
+
 		if ( addr == 0x5000 )
 		{
 			irq_pending = false;
 			return irq_ctr & 0xff;
 		}
-		
+
 		if ( addr == 0x5800 )
 		{
 			irq_pending = false;
 			return irq_ctr >> 8;
 		}
-		
+
 		return Nes_Mapper::read( time, addr );
 	}
-	
+
 	virtual bool write_intercepted( nes_time_t time, nes_addr_t addr, int data )
 	{
 		if ( addr == 0x4800 )
@@ -153,15 +161,15 @@ public:
 		{
 			return false;
 		}
-		
+
 		return true;
 	}
-	
+
 	virtual void write( nes_time_t, nes_addr_t addr, int data )
 	{
 		int reg = addr >> 11 & 0x0F;
 		regs [reg] = data;
-		
+
 		int prg_bank = reg - 0x0c;
 		if ( (unsigned) prg_bank < 3 )
 		{
@@ -184,6 +192,28 @@ public:
 	}
 };
 
+void namco106_state_t::swap()
+{
+	set_le16( &irq_ctr, irq_ctr );
+	for ( unsigned i = 0; i < sizeof sound_state.delays / sizeof sound_state.delays [0]; i++ )
+		set_le16( &sound_state.delays [i], sound_state.delays [i] );
+}
+
+void Mapper_Namco106::save_state( mapper_state_t& out )
+{
+	sound.save_state( &sound_state );
+	namco106_state_t::swap();
+	Nes_Mapper::save_state( out );
+	namco106_state_t::swap();
+}
+
+void Mapper_Namco106::read_state( mapper_state_t const& in )
+{
+	Nes_Mapper::read_state( in );
+	namco106_state_t::swap();
+	sound.load_state( sound_state );
+}
+
 void register_namco106_mapper();
 void register_namco106_mapper()
 {
@@ -205,13 +235,13 @@ void register_optional_mappers()
 
 	extern void register_vrc6_mapper();
 	register_vrc6_mapper();
-	
+
 	extern void register_mmc5_mapper();
 	register_mmc5_mapper();
-	
+
 	extern void register_fme7_mapper();
 	register_fme7_mapper();
-	
+
 	extern void register_namco106_mapper();
 	register_namco106_mapper();
 

--- a/nes_emu/Mapper_Namco54xx.cpp
+++ b/nes_emu/Mapper_Namco54xx.cpp
@@ -1,0 +1,160 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ * 3/24/18
+ *
+ * Mapper  88
+ * Mapper 154
+ * Mapper 206
+ */
+
+#include "Nes_Mapper.h"
+
+struct namco_34xx_state_t
+{
+	uint8_t bank [ 8 ];
+	uint8_t mirr;
+	uint8_t mode;
+};
+
+BOOST_STATIC_ASSERT( sizeof (namco_34xx_state_t) == 10 );
+
+template < bool _is154 >
+class Mapper_Namco_34x3 : public Nes_Mapper, namco_34xx_state_t {
+public:
+	Mapper_Namco_34x3()
+	{
+		namco_34xx_state_t *state = this;
+		register_state( state, sizeof *state );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		set_chr_bank( 0x0000, bank_2k, bank [ 0 ] );
+		set_chr_bank( 0x0800, bank_2k, bank [ 1 ] );
+		for ( int i = 0; i < 4; i++ )
+			set_chr_bank( 0x1000 + ( i << 10 ), bank_1k, bank [ i + 2 ] );
+
+		set_prg_bank( 0x8000, bank_8k, bank [ 6 ] );
+		set_prg_bank( 0xA000, bank_8k, bank [ 7 ] );
+		set_prg_bank( 0xC000, bank_8k, ~1 );
+		set_prg_bank( 0xE000, bank_8k, ~0 );
+
+		if ( _is154 )
+			mirror_single( mirr );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		switch ( addr & 0xE001 )
+		{
+		case 0x8000:
+			mode = data;
+			mirr = ( data >> 6 ) & 0x01;
+			if ( _is154 )
+				mirror_single( mirr );
+			break;
+		case 0x8001:
+			mode &= 0x07;
+			switch ( mode )
+			{
+			case 0: case 1:
+				bank [ mode ] = data >> 1;
+				set_chr_bank( 0x0000 + ( mode << 11 ), bank_2k, bank [ mode ] );
+				break;
+			case 2: case 3: case 4: case 5:
+				bank [ mode ] = data | 0x40;
+				set_chr_bank( 0x1000 + ( ( mode - 2 ) << 10 ), bank_1k, bank [ mode ] );
+				break;
+			case 6: case 7:
+				bank [ mode ] = data;
+				set_prg_bank( 0x8000 + ( ( mode - 6 ) << 13 ), bank_8k, bank [ mode ] );
+				break;
+			}
+			break;
+		case 0xC000:
+			mirr = ( data >> 6 ) & 0x01;
+			if ( _is154 )
+				mirror_single( mirr );
+		}
+	}
+};
+
+class Mapper_Namco_34xx : public Nes_Mapper, namco_34xx_state_t {
+public:
+	Mapper_Namco_34xx()
+	{
+		namco_34xx_state_t *state = this;
+		register_state( state, sizeof *state );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		set_chr_bank( 0x0000, bank_2k, bank [ 0 ] );
+		set_chr_bank( 0x0800, bank_2k, bank [ 1 ] );
+		for ( int i = 0; i < 4; i++ )
+			set_chr_bank( 0x1000 + ( i << 10 ), bank_1k, bank [ i + 2 ] );
+
+		set_prg_bank( 0x8000, bank_8k, bank [ 6 ] );
+		set_prg_bank( 0xA000, bank_8k, bank [ 7 ] );
+		set_prg_bank( 0xC000, bank_8k, ~1 );
+		set_prg_bank( 0xE000, bank_8k, ~0 );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		switch ( addr & 0xE001 )
+		{
+		case 0x8000:
+			mode = data;
+			break;
+		case 0x8001:
+			mode &= 0x07;
+			switch ( mode )
+			{
+			case 0: case 1:
+				bank [ mode ] = data >> 1;
+				set_chr_bank( 0x0000 + ( mode << 11 ), bank_2k, bank [ mode ] );
+				break;
+			case 2: case 3: case 4: case 5:
+				bank [ mode ] = data;
+				set_chr_bank( 0x1000 + ( ( mode - 2 ) << 10 ), bank_1k, bank [ mode ] );
+				break;
+			case 6: case 7:
+				bank [ mode ] = data;
+				set_prg_bank( 0x8000 + ( ( mode - 6 ) << 13 ), bank_8k, bank [ mode ] );
+				break;
+			}
+			break;
+		}
+	}
+};
+
+void register_mapper_namco_34xx();
+void register_mapper_namco_34xx()
+{
+	register_mapper< Mapper_Namco_34x3 <false> > ( 88 );
+	register_mapper< Mapper_Namco_34x3 <true> > ( 154 );
+	register_mapper< Mapper_Namco_34xx > ( 206 );
+}

--- a/nes_emu/Mapper_Sunsoft1.cpp
+++ b/nes_emu/Mapper_Sunsoft1.cpp
@@ -1,0 +1,64 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 184 - Sunsoft-1
+ */
+
+#include "Nes_Mapper.h"
+
+class Mapper_Sunsoft1 : public Nes_Mapper {
+public:
+	Mapper_Sunsoft1()
+	{
+		register_state( &regs, 1 );
+	}
+
+	virtual void reset_state()
+	{}
+
+	virtual void apply_mapping()
+	{
+		set_prg_bank( 0x8000, bank_32k, 0 );
+		intercept_writes( 0x6000, 1 );
+		write_intercepted( 0, 0x6000, regs );
+	}
+
+	virtual bool write_intercepted( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( addr != 0x6000 )
+			return false;
+
+		regs = data;
+		set_chr_bank( 0x0000, bank_4k, data & 0x07 );
+		set_chr_bank( 0x1000, bank_4k, ( data >> 4 ) & 0x07 );
+
+		return true;
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{}
+
+	uint8_t regs;
+};
+
+void register_mapper_sunsoft1();
+void register_mapper_sunsoft1()
+{
+	register_mapper< Mapper_Sunsoft1 > ( 184 );
+}

--- a/nes_emu/Mapper_Sunsoft2.cpp
+++ b/nes_emu/Mapper_Sunsoft2.cpp
@@ -1,0 +1,85 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 93 - Sunsoft-2
+ */
+
+#include "Nes_Mapper.h"
+
+class Mapper_Sunsoft2a : public Nes_Mapper {
+public:
+	Mapper_Sunsoft2a()
+	{
+		register_state( &regs, 1 );
+	}
+
+	virtual void reset_state()
+	{}
+
+	virtual void apply_mapping()
+	{
+		set_prg_bank( 0xC000, bank_16k, last_bank );
+		write( 0, 0x8000, regs );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		regs = handle_bus_conflict( addr, data );
+
+		set_chr_bank( 0x0000, bank_8k, data & 0x0F );
+		set_prg_bank( 0x8000, bank_16k, ( data >> 4 ) & 0x07 );
+	}
+
+	uint8_t regs;
+};
+
+class Mapper_Sunsoft2b : public Nes_Mapper {
+public:
+	Mapper_Sunsoft2b()
+	{
+		register_state( &regs, 1 );
+	}
+
+	virtual void reset_state()
+	{}
+
+	virtual void apply_mapping()
+	{
+		set_prg_bank( 0xC000, bank_16k, last_bank );
+		write( 0, 0x8000, regs );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		regs = handle_bus_conflict( addr, data );
+
+		set_chr_bank( 0x0000, bank_8k, ( ( data >> 4 ) & 0x08 ) | ( data & 0x07 ) );
+		set_prg_bank( 0x8000, bank_16k, ( data >> 4 ) & 0x07 );
+		mirror_single( ( data >> 3 ) & 1 );
+	}
+
+	uint8_t regs;
+};
+
+void register_mapper_sunsoft2();
+void register_mapper_sunsoft2()
+{
+	register_mapper< Mapper_Sunsoft2a > ( 93 );
+	register_mapper< Mapper_Sunsoft2b > ( 89 );
+}

--- a/nes_emu/Mapper_TaitoTC0190.cpp
+++ b/nes_emu/Mapper_TaitoTC0190.cpp
@@ -1,0 +1,95 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ *
+ * Mapper 33 - Taito TC0190
+ * 
+ */
+
+#include "Nes_Mapper.h"
+
+struct tc0190_state_t
+{
+	uint8_t preg [ 2 ];
+	uint8_t creg [ 6 ];
+	uint8_t mirr;
+};
+
+BOOST_STATIC_ASSERT( sizeof ( tc0190_state_t ) == 9 );
+
+class Mapper_TaitoTC0190 : public Nes_Mapper, tc0190_state_t {
+public:
+	Mapper_TaitoTC0190()
+	{
+		tc0190_state_t *state = this;
+		register_state( state, sizeof *state );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		for ( int i = 0; i < 2; i++ )
+		{
+			set_prg_bank ( 0x8000 + ( i << 13 ), bank_8k, preg [ i ] );
+			set_chr_bank ( 0x0000 + ( i << 11 ), bank_2k, creg [ i ] );
+		}
+
+		for ( int i = 0; i < 4; i++ )
+			set_chr_bank ( 0x1000 + ( i << 10 ), bank_1k, creg [ 2 + i ] );
+
+		if ( mirr ) mirror_horiz();
+		else mirror_vert();
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data )
+	{
+		switch ( addr & 0xA003 )
+		{
+		case 0x8000:
+			preg [ 0 ] = data & 0x3F;
+			mirr = data >> 6;
+			set_prg_bank ( 0x8000, bank_8k, preg [ 0 ] );
+			if ( mirr ) mirror_horiz();
+			else mirror_vert();
+			break;
+		case 0x8001:
+			preg [ 1 ] = data & 0x3F;
+			set_prg_bank ( 0xA000, bank_8k, preg [ 1 ] );
+			break;
+		case 0x8002: case 0x8003:
+			addr &= 0x01;
+			creg [ addr ] = data;
+			set_chr_bank ( addr << 11, bank_2k, creg [ addr ] );
+			break;
+		case 0xA000: case 0xA001:
+		case 0xA002: case 0xA003:
+			addr &= 0x03;
+			creg [ 2 + addr ] = data;
+			set_chr_bank ( 0x1000 | ( addr << 10 ), bank_1k, creg [ 2 + addr ] );
+			break;
+		}
+	}
+};
+
+void register_mapper_taito_tc0190();
+void register_mapper_taito_tc0190()
+{
+	register_mapper< Mapper_TaitoTC0190 > ( 33 );
+}

--- a/nes_emu/Mapper_TaitoX1005.cpp
+++ b/nes_emu/Mapper_TaitoX1005.cpp
@@ -1,0 +1,92 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ * 
+ * Taito's X1-005 ( Rev. B ) Fudou Myouou Den
+ *
+ */
+
+#include "Nes_Mapper.h"
+
+struct taito_x1005_state_t
+{
+	uint8_t preg [ 3 ];
+	uint8_t creg [ 6 ];
+	uint8_t nametable [ 2 ];
+};
+
+BOOST_STATIC_ASSERT( sizeof (taito_x1005_state_t) == 11 );
+
+class Mapper_TaitoX1005 : public Nes_Mapper, taito_x1005_state_t {
+public:
+	Mapper_TaitoX1005()
+	{
+		taito_x1005_state_t *state = this;
+		register_state( state, sizeof *state );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		int i;
+		intercept_writes( 0x7EF0, 1 );
+		for ( i = 0; i < 3; i++ )
+			set_prg_bank( 0x8000 + ( i << 13 ), bank_8k, preg [ i ] );
+		for ( i = 0; i < 2; i++ )
+			set_chr_bank( 0x0000 + ( i << 11 ), bank_2k, creg [ i ] >> 1);
+		for ( i = 0; i < 4; i++ )
+			set_chr_bank( 0x1000 + ( i << 10 ), bank_1k, creg [ 2 + i ] );
+		mirror_manual( nametable [ 0 ], nametable [ 0 ], nametable [ 1 ], nametable [ 1 ] );
+	}
+
+	virtual bool write_intercepted( nes_time_t, nes_addr_t addr, int data )
+	{
+		if ( addr < 0x7EF0 || addr > 0x7EFF )
+			return false;
+		
+		if ( ( addr & 0x0F ) < 6 )
+		{
+			creg [ addr & 0x07 ] = data;
+			if ( ( addr & 0x0F ) < 2 )
+			{
+				nametable [ addr & 0x01 ] = data >> 7;
+				mirror_manual( nametable [ 0 ], nametable [ 0 ], nametable [ 1 ], nametable [ 1 ] );
+				set_chr_bank( ( addr << 11 ) & 0x800, bank_2k, creg [ addr & 0x01 ] >> 1 );
+				return true;
+			}
+
+			set_chr_bank( 0x1000 | ( ( addr - 0x7EF2 ) << 10 ), bank_1k, creg [ addr & 0x07 ] );
+			return true;
+		}
+		
+		addr = ( addr - 0x7EFA ) >> 1;
+		preg [ addr ] = data;
+		set_prg_bank( 0x8000 | ( addr << 13 ), bank_8k, preg [ addr ] );
+		return true;
+	}
+
+	virtual void write( nes_time_t, nes_addr_t addr, int data ) { }
+};
+
+void register_mapper_taito_x1005();
+void register_mapper_taito_x1005()
+{
+	register_mapper< Mapper_TaitoX1005 > ( 207 );
+}

--- a/nes_emu/Mapper_Un1rom.cpp
+++ b/nes_emu/Mapper_Un1rom.cpp
@@ -1,0 +1,55 @@
+/* Copyright notice for this file:
+ * Copyright (C) 2018
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * This mapper was added by retrowertz for Libretro port of QuickNES.
+ * 
+ * Mapper 94 - HVC-UN1ROM
+ * Senjou no Ookami (Japanese version of Commando)
+ *
+ */
+
+#include "Nes_Mapper.h"
+ 
+class Mapper_Un1rom : public Nes_Mapper {
+public:
+	Mapper_Un1rom()
+	{
+		register_state( &bank, 1 );
+	}
+
+	virtual void reset_state()
+	{ }
+
+	virtual void apply_mapping()
+	{
+		write( 0, 0, bank );
+	}
+
+	virtual void write( nes_time_t, nes_addr_t, int data )
+	{
+		bank = data;
+		set_prg_bank( 0x8000, bank_16k, bank >> 2 );
+	}
+
+	uint8_t bank;
+};
+
+void register_mapper_un1rom();
+void register_mapper_un1rom()
+{
+	register_mapper< Mapper_Un1rom > ( 94 );
+}

--- a/nes_emu/Mappers.cpp
+++ b/nes_emu/Mappers.cpp
@@ -1,0 +1,74 @@
+extern void register_mapper_74x161x162x32();
+extern void register_mapper_180();
+extern void register_mapper_193();
+extern void register_mapper_234();
+extern void register_mapper_235();
+extern void register_mapper_240();
+extern void register_mapper_241();
+extern void register_mapper_244();
+extern void register_mapper_246();
+extern void register_mapper_avenina();
+extern void register_mapper_irem_g101();
+extern void register_mapper_irem_tamS1();
+extern void register_mapper_jaleco_jf11();
+extern void register_mapper_namco_34xx();
+extern void register_mapper_sunsoft1();
+extern void register_mapper_sunsoft2();
+extern void register_mapper_taito_tc0190();
+extern void register_mapper_taito_x1005();
+extern void register_mapper_un1rom();
+
+void register_extra_mappers();
+void register_extra_mappers()
+{
+	// Mapper 32
+	register_mapper_irem_g101();
+
+	// Mapper 33
+	register_mapper_taito_tc0190();
+
+	// Mapper 79, 113
+	register_mapper_avenina();
+
+	// Mapper 94
+	register_mapper_un1rom();
+
+	// Mapper 97
+	register_mapper_irem_tamS1();
+
+	// Mapper 140
+	register_mapper_jaleco_jf11();
+
+	// Mapper 184
+	register_mapper_sunsoft1();
+
+	// Mapper 89, 93
+	register_mapper_sunsoft2();
+
+	// Mapper 86, 152
+	register_mapper_74x161x162x32();
+
+	// Mapper 180
+	register_mapper_180();
+
+	// Mapper 193
+	register_mapper_193();
+
+	// Mapper 207
+	register_mapper_taito_x1005();
+
+	// Mapper 088, 154, 206
+	register_mapper_namco_34xx();
+
+	// Mapper 240
+	register_mapper_240();
+
+	// Mapper 241
+	register_mapper_241();
+
+	// Mapper 244
+	register_mapper_244();
+
+	// Mapper 246
+	register_mapper_246();
+}

--- a/nes_emu/Nes_Emu.h
+++ b/nes_emu/Nes_Emu.h
@@ -14,6 +14,7 @@ class Nes_State;
 
 // Register optional mappers included with Nes_Emu
 void register_optional_mappers();
+void register_extra_mappers();
 
 extern const char unsupported_mapper []; // returned when cartridge uses unsupported mapper
 

--- a/nes_emu/Nes_Mapper.cpp
+++ b/nes_emu/Nes_Mapper.cpp
@@ -161,7 +161,7 @@ int Nes_Mapper::handle_bus_conflict( nes_addr_t addr, int data )
 
 // Mapper registration
 
-int const max_mappers = 32;
+int const max_mappers = 64;
 Nes_Mapper::mapping_t Nes_Mapper::mappers [max_mappers] =
 {
 	{ 0, Nes_Mapper::make_nrom },

--- a/nes_emu/Nes_Namco_Apu.cpp
+++ b/nes_emu/Nes_Namco_Apu.cpp
@@ -31,11 +31,11 @@ void Nes_Namco_Apu::reset()
 {
 	last_time = 0;
 	addr_reg = 0;
-	
+
 	int i;
 	for ( i = 0; i < reg_count; i++ )
 		reg [i] = 0;
-	
+
 	for ( i = 0; i < osc_count; i++ )
 	{
 		Namco_Osc& osc = oscs [i];
@@ -55,12 +55,12 @@ void Nes_Namco_Apu::output( Blip_Buffer* buf )
 void Nes_Namco_Apu::reflect_state( Tagged_Data& data )
 {
 	reflect_int16( data, 'ADDR', &addr_reg );
-	
+
 	static const char hex [17] = "0123456789ABCDEF";
 	int i;
 	for ( i = 0; i < reg_count; i++ )
 		reflect_int16( data, 'RG\0\0' + hex [i >> 4] * 0x100 + hex [i & 15], &reg [i] );
-	
+
 	for ( i = 0; i < osc_count; i++ )
 	{
 		reflect_int32( data, 'DLY0' + i, &oscs [i].delay );
@@ -73,7 +73,7 @@ void Nes_Namco_Apu::end_frame( nes_time_t time )
 {
 	if ( time > last_time )
 		run_until( time );
-	
+
 	last_time -= time;
 }
 
@@ -86,7 +86,7 @@ void Nes_Namco_Apu::run_until( nes_time_t nes_end_time )
 		Blip_Buffer* output = osc.output;
 		if ( !output )
 			continue;
-		
+
 		blip_resampled_time_t time =
 				output->resampled_time( last_time ) + osc.delay;
 		blip_resampled_time_t end_time = output->resampled_time( nes_end_time );
@@ -96,24 +96,24 @@ void Nes_Namco_Apu::run_until( nes_time_t nes_end_time )
 			const uint8_t* osc_reg = &reg [i * 8 + 0x40];
 			if ( !(osc_reg [4] & 0xE0) )
 				continue;
-			
+
 			int volume = osc_reg [7] & 15;
 			if ( !volume )
 				continue;
-			
+
 			long freq = (osc_reg [4] & 3) * 0x10000 + osc_reg [2] * 0x100L + osc_reg [0];
 			if ( freq < 64 * active_oscs )
 				continue; // prevent low frequencies from excessively delaying freq changes
 			blip_resampled_time_t period =
 					output->resampled_duration( 983040 ) / freq * active_oscs;
-			
+
 			int wave_size = 32 - (osc_reg [4] >> 2 & 7) * 4;
 			if ( !wave_size )
 				continue;
-			
+
 			int last_amp = osc.last_amp;
 			int wave_pos = osc.wave_pos;
-			
+
 			do
 			{
 				// read wave sample
@@ -121,7 +121,7 @@ void Nes_Namco_Apu::run_until( nes_time_t nes_end_time )
 				int sample = reg [addr >> 1] >> (addr << 2 & 4);
 				wave_pos++;
 				sample = (sample & 15) * volume;
-				
+
 				// output impulse if amplitude changed
 				int delta = sample - last_amp;
 				if ( delta )
@@ -129,19 +129,52 @@ void Nes_Namco_Apu::run_until( nes_time_t nes_end_time )
 					last_amp = sample;
 					synth.offset_resampled( time, delta, output );
 				}
-				
+
 				// next sample
 				time += period;
 				if ( wave_pos >= wave_size )
 					wave_pos = 0;
 			}
 			while ( time < end_time );
-			
+
 			osc.wave_pos = wave_pos;
 			osc.last_amp = last_amp;
 		}
 		osc.delay = time - end_time;
 	}
-	
+
 	last_time = nes_end_time;
+}
+
+void Nes_Namco_Apu::save_state( namco_state_t* out ) const
+{
+	out->addr = addr_reg;
+	for ( int r = 0; r < reg_count; r++ )
+		out->regs [ r ] = reg [ r ];
+
+	for ( int i = 0; i < osc_count; i++ )
+	{
+		Namco_Osc const& osc = oscs [ i ];
+
+		out->delays [ i ] = osc.delay;
+		out->positions [ i ] = osc.wave_pos;
+	}
+}
+
+void Nes_Namco_Apu::load_state( namco_state_t const& in )
+{
+	reset();
+	addr_reg = in.addr;
+	for ( int r = 0; r < reg_count; r++ )
+		reg [ r ] = in.regs [ r ];
+
+	for ( int i = 0; i < osc_count; i++ )
+	{
+		Namco_Osc& osc = oscs [ i ];
+
+		osc.delay = in.delays [ i ];
+		osc.wave_pos = in.positions [ i ];
+	}
+
+	run_until( last_time );
 }

--- a/nes_emu/Nes_Namco_Apu.h
+++ b/nes_emu/Nes_Namco_Apu.h
@@ -15,7 +15,7 @@ class Nes_Namco_Apu {
 public:
 	Nes_Namco_Apu();
 	~Nes_Namco_Apu();
-	
+
 	// See Nes_Apu.h for reference.
 	void volume( double );
 	void treble_eq( const blip_eq_t& );
@@ -24,45 +24,45 @@ public:
 	void osc_output( int index, Blip_Buffer* );
 	void reset();
 	void end_frame( nes_time_t );
-	
+
 	// Read/write data register is at 0x4800
 	enum { data_reg_addr = 0x4800 };
 	void write_data( nes_time_t, int );
 	int read_data();
-	
+
 	// Write-only address register is at 0xF800
 	enum { addr_reg_addr = 0xF800 };
 	void write_addr( int );
-	
+
 	// to do: implement save/restore
 	void save_state( namco_state_t* out ) const;
 	void load_state( namco_state_t const& );
-	
+
 private:
 	// noncopyable
 	Nes_Namco_Apu( const Nes_Namco_Apu& );
 	Nes_Namco_Apu& operator = ( const Nes_Namco_Apu& );
-	
+
 	struct Namco_Osc {
 		long delay;
 		Blip_Buffer* output;
 		short last_amp;
 		short wave_pos;
 	};
-	
+
 	Namco_Osc oscs [osc_count];
-	
+
 	nes_time_t last_time;
 	int addr_reg;
-	
+
 	enum { reg_count = 0x80 };
 	uint8_t reg [reg_count];
 	Blip_Synth<blip_good_quality,15> synth;
-	
+
 	uint8_t& access();
 	void run_until( nes_time_t );
 };
-/*
+
 struct namco_state_t
 {
 	uint8_t regs [0x80];
@@ -71,7 +71,8 @@ struct namco_state_t
 	uint8_t positions [8];
 	uint32_t delays [8];
 };
-*/
+
+BOOST_STATIC_ASSERT( sizeof (namco_state_t) == 172 );
 
 inline uint8_t& Nes_Namco_Apu::access()
 {


### PR DESCRIPTION
- Add support for additional mappers.
- Added save state function in Namco 106 mapper
- Enable soft-reset ( Experimental ) - by default a reset always do a full reset. its possible to have a soft-reset by passing false, false to emu->reset() (1st one is RAM clear, 2nd arg is for sram clear, if not battery enabled)