### PR TITLE
Add stereo panning audio effect

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -113,7 +113,7 @@ void retro_set_environment(retro_environment_t cb)
       { "quicknes_use_overscan_v", "Show vertical overscan; disabled|enabled" },
 #endif
       { "quicknes_no_sprite_limit", "No sprite limit; enabled|disabled" },
-      { "quicknes_audio_nonlinear", "Audio linear/nonlinear; nonlinear|linear|stereo panning"},
+      { "quicknes_audio_nonlinear", "Audio mode; nonlinear|linear|stereo panning"},
       { "quicknes_audio_eq", "Audio equalizer preset; default|famicom|tv|flat|crisp|tinny"},
       { NULL, NULL },
    };

--- a/nes_emu/Blip_Buffer.cpp
+++ b/nes_emu/Blip_Buffer.cpp
@@ -80,7 +80,6 @@ const char *Blip_Buffer::set_sample_rate( long new_rate, int msec )
 	}
 	
 	buffer_size_ = new_size;
-	
 	// update things based on the sample rate
 	sample_rate_ = new_rate;
 	length_ = new_size * 1000 / new_rate - 1;

--- a/nes_emu/Nes_Effects_Buffer.cpp
+++ b/nes_emu/Nes_Effects_Buffer.cpp
@@ -81,3 +81,11 @@ long Nes_Effects_Buffer::read_samples( blip_sample_t* out, long count )
 	count = 2 * nonlin.make_nonlinear( *channel( 2 ).center, count / 2 );
 	return Effects_Buffer::read_samples( out, count );
 }
+
+void Nes_Effects_Buffer::SaveAudioBufferState()
+{
+}
+
+void Nes_Effects_Buffer::RestoreAudioBufferState()
+{
+}

--- a/nes_emu/Nes_Effects_Buffer.h
+++ b/nes_emu/Nes_Effects_Buffer.h
@@ -28,6 +28,9 @@ public:
 	void clear();
 	channel_t channel( int );
 	long read_samples( blip_sample_t*, long );
+
+	void SaveAudioBufferState();
+	void RestoreAudioBufferState();
 	
 private:
 	Nes_Nonlinearizer nonlin;


### PR DESCRIPTION
- Add stereo panning option, which simulates stereo option using panning method and some reverb effects to add some depth.
We don't currently have a similar audio filter like this at the moment, we can probably remove this when similar audio filter is added.
- Renamed  Audio linear/nonlinear to Audio mode to reflect the change since it shares the same menu entry and/or method of switching between the buffers to use.

