### PR TITLE
(av_info) Set correct maximum framebuffer dimensions

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -98,8 +98,8 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
 
    info->geometry.base_width   = width;
    info->geometry.base_height  = height;
-   info->geometry.max_width    = width;
-   info->geometry.max_height   = height;
+   info->geometry.max_width    = Nes_Emu::image_width;
+   info->geometry.max_height   = Nes_Emu::image_height;
    info->geometry.aspect_ratio = get_aspect_ratio(width, height);
 }
 


### PR DESCRIPTION
At present, the core causes RetroArch to segfault if the 'show overscan' options are toggled from off to on while using a CPU filter. This is because the maximum framebuffer dimensions are always set to the current screen size, and when the current screen size increases (i.e. show overscan) we only get a call to RETRO_ENVIRONMENT_SET_GEOMETRY, not RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO. The CPU filter video buffer therefore ends up being too small, and we get an access violation. (To be fair, this looks like a simple typo... and ironically, I just noticed I made a typo in the commit message...)

This pull request sets the max width/height correctly, and fixes the issue.