### PR TITLE
Add PS2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,17 @@ else ifeq ($(platform), psl1ght)
 	PLATFORM_DEFINES := -D__CELLOS_LV2__ -DMSB_FIRST
 	STATIC_LINKING = 1
 
+# PS2
+else ifeq ($(platform), ps2)
+	TARGET := $(TARGET_NAME)_libretro_$(platform).a
+	CC = ee-gcc$(EXE_EXT)
+	CXX = ee-g++$(EXE_EXT)
+	AR = ee-ar$(EXE_EXT)
+	PLATFORM_DEFINES := -DPS2 -G0 -DNO_UNALIGNED_ACCESS -fsingle-precision-constant
+	PLATFORM_DEFINES += -I$(PS2SDK)/ee/include -I$(PS2SDK)/common/include -Ips2/
+	CXXFLAGS += -fno-rtti -fno-exceptions
+	STATIC_LINKING = 1
+
 # PSP
 else ifeq ($(platform), psp1)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a

--- a/ps2/stdint.h
+++ b/ps2/stdint.h
@@ -1,0 +1,30 @@
+#ifndef STDINT_H
+#define STDINT_H
+
+typedef unsigned long     uintptr_t;
+typedef signed long       intptr_t;
+
+typedef signed char       int8_t;
+typedef signed short      int16_t;
+typedef signed int        int32_t;
+typedef signed long       int64_t;
+typedef unsigned char     uint8_t;
+typedef unsigned short    uint16_t;
+typedef unsigned int      uint32_t;
+typedef unsigned long     uint64_t;
+
+#define	 STDIN_FILENO	0	/* standard input file descriptor */
+#define	STDOUT_FILENO	1	/* standard output file descriptor */
+#define	STDERR_FILENO	2	/* standard error file descriptor */
+
+#define INT8_C(val)  val##c
+#define INT16_C(val) val##h
+#define INT32_C(val) val##i
+#define INT64_C(val) val##l
+
+#define UINT8_C(val)  val##uc
+#define UINT16_C(val) val##uh
+#define UINT32_C(val) val##ui
+#define UINT64_C(val) val##ul
+
+#endif //STDINT_H


### PR DESCRIPTION
This PR is adding the PS2 support to QuickNes using libretro.

The PR change 2 files:

1. `Makefile.libretro`
Creating a specific section for the PS2

2. `ps2/stdint.h`
Adding a new file missing in the PS2SDK

Thanks
