### PR TITLE
Prevent division by zero

### DIFF
--- a/nes_emu/Nes_Buffer.cpp
+++ b/nes_emu/Nes_Buffer.cpp
@@ -168,7 +168,10 @@ Nes_Nonlinearizer::Nes_Nonlinearizer()
 		int const offset = table_size - range;
 		int j = i - offset;
 		float n = 202.0f / (range - 1) * j;
-		float d = gain * 163.67f / (24329.0f / n + 100.0f);
+		float d = 0;
+		// Prevent division by zero
+		if ( n )
+			d = gain * 163.67f / (24329.0f / n + 100.0f);
 		int out = (int) d;
 		table [j & (table_size - 1)] = out;
 	}


### PR DESCRIPTION
Fixes #66

This will set `table[0] = 0`, which seems reasonable based on the other values in the table.

Feel free to clean up the code as needed.

Thanks!