### PR TITLE
Bypass unaligned access debugging on PSP

### DIFF
--- a/nes_emu/Nes_Ppu_Impl.cpp
+++ b/nes_emu/Nes_Ppu_Impl.cpp
@@ -37,8 +37,8 @@ Nes_Ppu_Impl::Nes_Ppu_Impl()
 	mmc24_enabled = false;
 	mmc24_latched[0] = 0;
 	mmc24_latched[1] = 0;
-	
-	#ifndef NDEBUG
+
+	#if !defined(NDEBUG) && !defined(PSP)
 		// verify that unaligned accesses work
 		static unsigned char b  [19] = { 0 };
 		static unsigned char b2 [19] = { 1,2,3,4,0,5,6,7,8,0,9,0,1,2,0,3,4,5,6 };


### PR DESCRIPTION
Fixes #71

I'm not entirely sure what this is doing, but the PSP doesn't like it. Maybe it's related to MIPS' alignment requirements?

At any rate, it's debugging code that doesn't actually seem to do anything. (In the upstream source there's an `assert` that's been removed from this core: https://github.com/kode54/QuickNES_Core/blob/master/nes_emu/Nes_Ppu_Impl.cpp#L43)

Feel free to edit as needed.

Thanks!