### PR TITLE
Add a Pixel Perfect option

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -25,7 +25,7 @@
 
 #define NES_4_3 (4.0 / 3.0)
 #define NES_PAR (width * (8.0 / 7.0) / height)
-#define NES_PP (width * (32.0 / 30.0) / height)
+#define NES_PP (width * (16.0 / 15.0) / height)
 
 static Nes_Emu *emu;
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -644,7 +644,7 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-     int newval = aspect_ratio_par;
+     int pre_aspect_ratio_par = aspect_ratio_par;
      if (!strcmp(var.value, "PAR"))
        aspect_ratio_par = 1;
      else if (!strcmp(var.value, "4:3"))
@@ -653,7 +653,7 @@ static void check_variables(void)
        aspect_ratio_par = 3;
      else
        aspect_ratio_par = 0;
-     if aspect_ratio_par != newval
+     if aspect_ratio_par != pre_aspect_ratio_par
          video_changed = true;
    }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -645,7 +645,7 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-     int last_aspect_ratio_par = aspect_ratio_par;
+     last_aspect_ratio_par = aspect_ratio_par;
      if (!strcmp(var.value, "PAR")) {
        aspect_ratio_par = 1;
      } else if (!strcmp(var.value, "4:3")) {

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -643,6 +643,7 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
+     int newval = aspect_ratio_par;
      if (!strcmp(var.value, "PAR"))
        aspect_ratio_par = 1;
      else if (!strcmp(var.value, "4:3"))
@@ -651,6 +652,8 @@ static void check_variables(void)
        aspect_ratio_par = 3;
      else
        aspect_ratio_par = 0;
+     if aspect_ratio_par != newval
+         video_changed = true;
    }
 
    var.key = "quicknes_up_down_allowed";

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -35,8 +35,9 @@ static retro_audio_sample_batch_t audio_batch_cb;
 static retro_environment_t environ_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
-static unsigned aspect_ratio_par;
-static unsigned aspect_ratio_type;
+static int aspect_ratio_par = 1;
+static int last_aspect_ratio_par = -1;
+static float aspect_ratio_type;
 #ifdef PSP
 static bool use_overscan;
 #else
@@ -426,13 +427,13 @@ void retro_get_system_info(struct retro_system_info *info)
 
 float get_aspect_ratio(unsigned width, unsigned height)
 {
-  if (aspect_ratio_par == 1)
+  if (aspect_ratio_par == 1) {
     aspect_ratio_type = NES_PAR;
-  if (aspect_ratio_par == 2)
+  } else if (aspect_ratio_par == 2) {
     aspect_ratio_type = NES_4_3;
-  if (aspect_ratio_par == 3)
+  } else if (aspect_ratio_par == 3) {
     aspect_ratio_type = NES_PP;
-    
+  }
   return aspect_ratio_type;
 }
 
@@ -644,14 +645,15 @@ static void check_variables(void)
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-     int pre_aspect_ratio_par = aspect_ratio_par;
-     if (!strcmp(var.value, "PAR"))
+     int last_aspect_ratio_par = aspect_ratio_par;
+     if (!strcmp(var.value, "PAR")) {
        aspect_ratio_par = 1;
-     else if (!strcmp(var.value, "4:3"))
+     } else if (!strcmp(var.value, "4:3")) {
        aspect_ratio_par = 2;
-     if (!strcmp(var.value, "PP"))
+     } else if (!strcmp(var.value, "PP")) {
        aspect_ratio_par = 3;
-     if (aspect_ratio_par != pre_aspect_ratio_par)
+     }
+     if (aspect_ratio_par != last_aspect_ratio_par)
          video_changed = true;
    }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -24,7 +24,7 @@
 #define CORE_VERSION "1.0-WIP"
 
 #define NES_4_3 (4.0 / 3.0)
-#define NES_PAR (width * (8.0 / 7.0) / height)
+#define NES_PAR ((width * (8.0 / 7.0)) / (height * (256.0 / 240.0)))
 
 static Nes_Emu *emu;
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -35,7 +35,7 @@ static retro_audio_sample_batch_t audio_batch_cb;
 static retro_environment_t environ_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
-static unsigned aspect_ratio_par;
+static int aspect_ratio_par;
 static unsigned aspect_ratio_type;
 #ifdef PSP
 static bool use_overscan;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -653,7 +653,7 @@ static void check_variables(void)
        aspect_ratio_par = 3;
      else
        aspect_ratio_par = 0;
-     if aspect_ratio_par != pre_aspect_ratio_par
+     if (aspect_ratio_par != pre_aspect_ratio_par)
          video_changed = true;
    }
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -24,7 +24,7 @@
 #define CORE_VERSION "1.0-WIP"
 
 #define NES_4_3 (4.0 / 3.0)
-#define NES_PAR (width / height)
+##define NES_PAR ((width * (8.0 / 7.0)) / (height * (256.0 / 240.0)))
 
 static Nes_Emu *emu;
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -35,7 +35,7 @@ static retro_audio_sample_batch_t audio_batch_cb;
 static retro_environment_t environ_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
-static int aspect_ratio_par;
+static unsigned aspect_ratio_par;
 static unsigned aspect_ratio_type;
 #ifdef PSP
 static bool use_overscan;
@@ -428,9 +428,9 @@ float get_aspect_ratio(unsigned width, unsigned height)
 {
   if (aspect_ratio_par == 1)
     aspect_ratio_type = NES_PAR;
-  else if (aspect_ratio_par == 2)
+  if (aspect_ratio_par == 2)
     aspect_ratio_type = NES_4_3;
-  else if (aspect_ratio_par == 3)
+  if (aspect_ratio_par == 3)
     aspect_ratio_type = NES_PP;
     
   return aspect_ratio_type;
@@ -649,10 +649,8 @@ static void check_variables(void)
        aspect_ratio_par = 1;
      else if (!strcmp(var.value, "4:3"))
        aspect_ratio_par = 2;
-     else if (!strcmp(var.value, "PP"))
+     if (!strcmp(var.value, "PP"))
        aspect_ratio_par = 3;
-     else
-       aspect_ratio_par = 0;
      if (aspect_ratio_par != pre_aspect_ratio_par)
          video_changed = true;
    }

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -24,7 +24,7 @@
 #define CORE_VERSION "1.0-WIP"
 
 #define NES_4_3 (4.0 / 3.0)
-##define NES_PAR ((width * (8.0 / 7.0)) / (height * (256.0 / 240.0)))
+#define NES_PAR ((width * (8.0 / 7.0)) / (height * (256.0 / 240.0)))
 
 static Nes_Emu *emu;
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -24,7 +24,7 @@
 #define CORE_VERSION "1.0-WIP"
 
 #define NES_4_3 (4.0 / 3.0)
-#define NES_PAR ((width * (8.0 / 7.0)) / (height * (256.0 / 240.0)))
+#define NES_PAR (width / height)
 
 static Nes_Emu *emu;
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -25,7 +25,7 @@
 
 #define NES_4_3 (4.0 / 3.0)
 #define NES_PAR (width * (8.0 / 7.0) / height)
-#define NES_PP (width / height)
+#define NES_PP (width * (32.0 / 30.0) / height)
 
 static Nes_Emu *emu;
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -35,8 +35,8 @@ static retro_audio_sample_batch_t audio_batch_cb;
 static retro_environment_t environ_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
-static int aspect_ratio_par = 1;
-static int last_aspect_ratio_par = -1;
+static int aspect_ratio_par;
+static int last_aspect_ratio_par;
 static float aspect_ratio_type;
 #ifdef PSP
 static bool use_overscan;

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -36,6 +36,7 @@ static retro_environment_t environ_cb;
 static retro_input_poll_t input_poll_cb;
 static retro_input_state_t input_state_cb;
 static unsigned aspect_ratio_par;
+static unsigned aspect_ratio_type;
 #ifdef PSP
 static bool use_overscan;
 #else

--- a/libretro/libretro_core_options.h
+++ b/libretro/libretro_core_options.h
@@ -67,6 +67,7 @@ struct retro_core_option_definition option_defs_us[] = {
       {
          { "PAR", NULL },
          { "4:3", NULL },
+         { "PP", NULL },
          { NULL, NULL },
       },
       "PAR",

--- a/libretro/libretro_core_options_intl.h
+++ b/libretro/libretro_core_options_intl.h
@@ -90,6 +90,7 @@ struct retro_core_option_definition option_defs_tr[] = {
       {
          { "PAR", NULL },
          { "4:3", NULL },
+         { "PP", NULL },
          { NULL, NULL },
       },
       NULL,


### PR DESCRIPTION
Some trial and error with getting pixel perfect (16:15) working without having stretch from cropping. Finally Mario games will have perfect squares.