### PR TITLE
Add support for RS90

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,6 +334,19 @@ else ifeq ($(platform), emscripten)
 	TARGET := $(TARGET_NAME)_libretro_$(platform).bc
 	STATIC_LINKING = 1
 
+
+# RS90
+else ifeq ($(platform), rs90)
+	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+	CXX = /opt/rs90-toolchain/usr/bin/mipsel-linux-g++
+	AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+	fpic := -fPIC
+	SHARED := -shared -Wl,-version-script=link.T -Wl,-no-undefined
+	PLATFORM_DEFINES := -DNO_UNALIGNED_ACCESS
+	PLATFORM_DEFINES += -O3 -fomit-frame-pointer -march=mips32 -mtune=mips32 -ffast-math
+	CXXFLAGS += -fno-rtti -fno-exceptions
+
 # GCW0
 else ifeq ($(platform), gcw0)
 	TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
Add support for the RS90.

Tested Zelda, loads and plays at full speed

More information on the platform here: https://github.com/libretro/RetroArch/pull/12592