### PR TITLE
add FORCE_STATUS def to quickly display status update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ else ifeq ($(platform), miyoo)
 	AR = /opt/miyoo/usr/bin/arm-linux-ar
 	fpic := -fPIC
 	SHARED := -shared -Wl,-version-script=link.T -Wl,-no-undefined
-	PLATFORM_DEFINES := -DNO_UNALIGNED_ACCESS
+	PLATFORM_DEFINES := -DNO_UNALIGNED_ACCESS -DFORCE_STATUS
 	PLATFORM_DEFINES += -O3 -fomit-frame-pointer -march=armv5te -mtune=arm926ej-s -ffast-math
 	CXXFLAGS += -fno-rtti -fno-exceptions
 

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -510,7 +510,7 @@ static void palette_switch_set_index(int palette_index)
          RETRO_LOG_INFO,
          RETRO_MESSAGE_TARGET_OSD,
 #ifdef FORCE_STATUS
-         RETRO_MESSAGE_TYPE_STATUS,
+         RETRO_MESSAGE_TYPE_STATUS, // force next notification to display
 #else
          RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
 #endif

--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -509,7 +509,11 @@ static void palette_switch_set_index(int palette_index)
          1,
          RETRO_LOG_INFO,
          RETRO_MESSAGE_TARGET_OSD,
+#ifdef FORCE_STATUS
+         RETRO_MESSAGE_TYPE_STATUS,
+#else
          RETRO_MESSAGE_TYPE_NOTIFICATION_ALT,
+#endif
          -1
       };
       environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE_EXT, &msg);


### PR DESCRIPTION
- adding option to enable RETRO_MESSAGE_TYPE_STATUS for non-widget platforms
- include -DFORCE_STATUS under Miyoo platform

Tested on Powkiddy V90, will force update of displayed message to currently passed one - useful especially when it's done in short periods e.g. for color pallete changing (following https://github.com/libretro/RetroArch/issues/14673#issuecomment-1328223242)